### PR TITLE
Add mock responses for web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This plugin is based on [CapGo's Capacitor plugin](https://www.npmjs.com/package
 <docgen-index>
 
 * [`configure(...)`](#configure)
+* [`setMockWebResults(...)`](#setmockwebresults)
 * [`setFinishTransactions(...)`](#setfinishtransactions)
 * [`setSimulatesAskToBuyInSandbox(...)`](#setsimulatesasktobuyinsandbox)
 * [`addCustomerInfoUpdateListener(...)`](#addcustomerinfoupdatelistener)
@@ -127,6 +128,23 @@ Sets up Purchases with your API key and an app user id.
 | Param               | Type                                                                      | Description                                                                                                                                                   |
 | ------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`configuration`** | <code><a href="#purchasesconfiguration">PurchasesConfiguration</a></code> | RevenueCat configuration object including the API key and other optional parameters. See {@link <a href="#purchasesconfiguration">PurchasesConfiguration</a>} |
+
+--------------------
+
+
+### setMockWebResults(...)
+
+```typescript
+setMockWebResults(options: { shouldMockWebResults: boolean; }) => Promise<void>
+```
+
+Sets whether the SDK should return mocked results in the web version.
+This won't affect the iOS and Android versions of the implementation.
+Default is false
+
+| Param         | Type                                            | Description                                                                             |
+| ------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **`options`** | <code>{ shouldMockWebResults: boolean; }</code> | Set shouldMockWebResults to true if you want the plugin methods to return mocked values |
 
 --------------------
 

--- a/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
+++ b/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
@@ -100,6 +100,15 @@ class PurchasesPlugin : Plugin() {
     }
 
     @PluginMethod(returnType = PluginMethod.RETURN_NONE)
+    fun setMockWebResults(call: PluginCall) {
+        Log.e(
+            "PurchasesCapacitor",
+            "Cannot enable mock web results in Android."
+        )
+        call.resolve()
+    }
+
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun setFinishTransactions(call: PluginCall) {
         if (rejectIfNotConfigured(call)) return
         val finishTransactions = call.getBooleanOrReject("finishTransactions") ?: return

--- a/example/purchase-tester/src/components/FunctionTesterContainer.tsx
+++ b/example/purchase-tester/src/components/FunctionTesterContainer.tsx
@@ -2,18 +2,19 @@ import './FunctionTesterContainer.css';
 import {IonButton, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle} from "@ionic/react";
 import React, {useEffect, useState} from "react";
 import {
-  LOG_LEVEL,
-  PRODUCT_CATEGORY,
   PurchaseDiscountedPackageOptions,
   Purchases
 } from "@revenuecat/purchases-capacitor";
+
 import {REVENUECAT_API_KEY} from "../constants";
+import {LOG_LEVEL, PRODUCT_CATEGORY} from "@revenuecat/purchases-typescript-internal";
 
 interface ContainerProps { }
 
 const FunctionTesterContainer: React.FC<ContainerProps> = () => {
   useEffect(() => {
     (async function () {
+      await Purchases.setMockWebResults({ shouldMockWebResults: true })
       await Purchases.setLogLevel({ level: LOG_LEVEL.VERBOSE });
     })();
   }, []);

--- a/ios/Plugin/PurchasesPlugin.m
+++ b/ios/Plugin/PurchasesPlugin.m
@@ -5,6 +5,7 @@
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(PurchasesPlugin, "Purchases",
            CAP_PLUGIN_METHOD(configure, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(setMockWebResults, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(setFinishTransactions, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(setSimulatesAskToBuyInSandbox, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(getOfferings, CAPPluginReturnPromise);

--- a/ios/Plugin/PurchasesPlugin.swift
+++ b/ios/Plugin/PurchasesPlugin.swift
@@ -44,6 +44,7 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate {
     }
 
     @objc func setMockWebResults(_ call: CAPPluginCall) {
+        NSLog("Cannot enable mock web results in iOS.")
         call.resolve()
     }
 

--- a/ios/Plugin/PurchasesPlugin.swift
+++ b/ios/Plugin/PurchasesPlugin.swift
@@ -43,6 +43,10 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate {
         call.resolve()
     }
 
+    @objc func setMockWebResults(_ call: CAPPluginCall) {
+        call.resolve()
+    }
+
     @objc func setFinishTransactions(_ call: CAPPluginCall) {
         guard self.rejectIfPurchasesNotConfigured(call) else { return }
         guard let finishTransactions = call.getOrRejectBool("finishTransactions") else { return }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -153,6 +153,14 @@ export interface PurchasesPlugin {
   configure(configuration: PurchasesConfiguration): Promise<void>;
 
   /**
+   * Sets whether the SDK should return mocked results in the web version.
+   * This won't affect the iOS and Android versions of the implementation.
+   * Default is false
+   * @param options Set shouldMockWebResults to true if you want the plugin methods to return mocked values
+   */
+  setMockWebResults(options: { shouldMockWebResults: boolean }): Promise<void>;
+
+  /**
    * @param options Set finishTransactions to false if you aren't using Purchases SDK to
    * make the purchase
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet.

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { WebPlugin } from '@capacitor/core';
+import {WebPlugin} from '@capacitor/core';
 import type {
   BILLING_FEATURE,
   CustomerInfo,
@@ -15,9 +15,9 @@ import type {
   PurchasesOfferings,
   PurchasesPromotionalOffer,
   PurchasesStoreProduct,
-  REFUND_REQUEST_STATUS,
   ShouldPurchasePromoProductListener,
 } from '@revenuecat/purchases-typescript-internal';
+import {REFUND_REQUEST_STATUS} from '@revenuecat/purchases-typescript-internal'
 
 import type {
   GetProductOptions,
@@ -32,220 +32,298 @@ import type {
 } from './definitions';
 
 export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
+  private shouldMockWebResults = false;
   private webNotSupportedErrorMessage = 'Web not supported in this plugin.';
 
   configure(_configuration: PurchasesConfiguration): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('configure');
   }
+
+  setMockWebResults(options: { shouldMockWebResults: boolean }): Promise<void> {
+    this.shouldMockWebResults = options.shouldMockWebResults;
+    return Promise.resolve();
+  }
+
   setFinishTransactions(_finishTransactions: {
     finishTransactions: boolean;
   }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setFinishTransactions');
   }
   setSimulatesAskToBuyInSandbox(_simulatesAskToBuyInSandbox: {
     simulatesAskToBuyInSandbox: boolean;
   }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setSimulatesAskToBuyInSandbox');
   }
   addCustomerInfoUpdateListener(
     _customerInfoUpdateListener: CustomerInfoUpdateListener,
   ): Promise<string> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockReturningFunctionIfEnabled('addCustomerInfoUpdateListener', 'mock-callback-id');
   }
   removeCustomerInfoUpdateListener(
     _listenerToRemove: string,
   ): Promise<{ wasRemoved: boolean }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockReturningFunctionIfEnabled('removeCustomerInfoUpdateListener', { wasRemoved: false});
   }
   addShouldPurchasePromoProductListener(
     _shouldPurchasePromoProductListener: ShouldPurchasePromoProductListener,
   ): Promise<string> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockReturningFunctionIfEnabled('addShouldPurchasePromoProductListener', 'mock-callback-id');
   }
   removeShouldPurchasePromoProductListener(
     _listenerToRemove: string,
   ): Promise<{ wasRemoved: boolean }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockReturningFunctionIfEnabled('removeShouldPurchasePromoProductListener', { wasRemoved: false});
   }
   getOfferings(): Promise<PurchasesOfferings> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockOfferings: PurchasesOfferings = {
+      all: {},
+      current: null
+    }
+    return this.mockReturningFunctionIfEnabled('getOfferings', mockOfferings);
   }
   getProducts(
     _options: GetProductOptions,
   ): Promise<{ products: PurchasesStoreProduct[] }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockProducts = { products: [] };
+    return this.mockReturningFunctionIfEnabled('getProducts', mockProducts);
   }
   purchaseStoreProduct(
     _options: PurchaseStoreProductOptions,
   ): Promise<MakePurchaseResult> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockPurchaseResult: MakePurchaseResult = {
+      productIdentifier: _options.product.identifier,
+      customerInfo: this.mockEmptyCustomerInfo,
+    };
+    return this.mockReturningFunctionIfEnabled('purchaseStoreProduct', mockPurchaseResult);
   }
   purchaseDiscountedProduct(
     _options: PurchaseDiscountedProductOptions,
   ): Promise<MakePurchaseResult> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockPurchaseResult: MakePurchaseResult = {
+      productIdentifier: _options.product.identifier,
+      customerInfo: this.mockEmptyCustomerInfo,
+    };
+    return this.mockReturningFunctionIfEnabled('purchaseDiscountedProduct', mockPurchaseResult);
   }
   purchasePackage(
     _options: PurchasePackageOptions,
   ): Promise<MakePurchaseResult> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockPurchaseResult: MakePurchaseResult = {
+      productIdentifier: _options.aPackage.product.identifier,
+      customerInfo: this.mockEmptyCustomerInfo,
+    };
+    return this.mockReturningFunctionIfEnabled('purchasePackage', mockPurchaseResult);
   }
   purchaseSubscriptionOption(
     _options: PurchaseSubscriptionOptionOptions,
   ): Promise<MakePurchaseResult> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockPurchaseResult: MakePurchaseResult = {
+      productIdentifier: _options.subscriptionOption.productId,
+      customerInfo: this.mockEmptyCustomerInfo,
+    };
+    return this.mockReturningFunctionIfEnabled('purchaseSubscriptionOption', mockPurchaseResult);
   }
   purchaseDiscountedPackage(
     _options: PurchaseDiscountedPackageOptions,
   ): Promise<MakePurchaseResult> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockPurchaseResult: MakePurchaseResult = {
+      productIdentifier: _options.aPackage.product.identifier,
+      customerInfo: this.mockEmptyCustomerInfo,
+    };
+    return this.mockReturningFunctionIfEnabled('purchaseDiscountedPackage', mockPurchaseResult);
   }
   restorePurchases(): Promise<{ customerInfo: CustomerInfo }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockResponse = { customerInfo: this.mockEmptyCustomerInfo }
+    return this.mockReturningFunctionIfEnabled('restorePurchases', mockResponse);
   }
   getAppUserID(): Promise<{ appUserID: string }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockReturningFunctionIfEnabled('getAppUserID', { appUserID: 'test-web-user-id'});
   }
   logIn(_appUserID: { appUserID: string }): Promise<LogInResult> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockLogInResult: LogInResult = {
+      customerInfo: this.mockEmptyCustomerInfo,
+      created: false,
+    }
+    return this.mockReturningFunctionIfEnabled('logIn', mockLogInResult);
   }
   logOut(): Promise<{ customerInfo: CustomerInfo }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockResponse = { customerInfo: this.mockEmptyCustomerInfo }
+    return this.mockReturningFunctionIfEnabled('logOut', mockResponse);
   }
   setLogLevel(_level: { level: LOG_LEVEL }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setLogLevel');
   }
   setLogHandler(_logHandler: LogHandler): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setLogHandler');
   }
   getCustomerInfo(): Promise<{ customerInfo: CustomerInfo }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockResponse = { customerInfo: this.mockEmptyCustomerInfo }
+    return this.mockReturningFunctionIfEnabled('getCustomerInfo', mockResponse);
   }
   syncPurchases(): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('syncPurchases');
   }
   syncObserverModeAmazonPurchase(
     _options: SyncObserverModeAmazonPurchaseOptions,
   ): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('syncObserverModeAmazonPurchase');
   }
   enableAdServicesAttributionTokenCollection(): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('enableAdServicesAttributionTokenCollection');
   }
   isAnonymous(): Promise<{ isAnonymous: boolean }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockResponse = { isAnonymous: false }
+    return this.mockReturningFunctionIfEnabled('isAnonymous', mockResponse);
   }
   checkTrialOrIntroductoryPriceEligibility(_productIdentifiers: {
     productIdentifiers: string[];
   }): Promise<{ [productId: string]: IntroEligibility }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockReturningFunctionIfEnabled('checkTrialOrIntroductoryPriceEligibility', {});
   }
   getPromotionalOffer(
     _options: GetPromotionalOfferOptions,
   ): Promise<PurchasesPromotionalOffer | undefined> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockReturningFunctionIfEnabled('getPromotionalOffer', undefined);
   }
   invalidateCustomerInfoCache(): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('invalidateCustomerInfoCache');
   }
   presentCodeRedemptionSheet(): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('presentCodeRedemptionSheet');
   }
   setAttributes(_attributes: { [key: string]: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setAttributes');
   }
   setEmail(_email: { email: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setEmail');
   }
   setPhoneNumber(_phoneNumber: { phoneNumber: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setPhoneNumber');
   }
   setDisplayName(_displayName: { displayName: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setDisplayName');
   }
   setPushToken(_pushToken: { pushToken: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setPushToken');
   }
   setProxyURL(_url: { url: string }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setProxyURL');
   }
   collectDeviceIdentifiers(): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('collectDeviceIdentifiers');
   }
   setAdjustID(_adjustID: { adjustID: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setAdjustID');
   }
   setAppsflyerID(_appsflyerID: { appsflyerID: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setAppsflyerID');
   }
   setFBAnonymousID(_fbAnonymousID: {
     fbAnonymousID: string | null;
   }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setFBAnonymousID');
   }
   setMparticleID(_mparticleID: { mparticleID: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setMparticleID');
   }
   setCleverTapID(_cleverTapID: { cleverTapID: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setCleverTapID');
   }
   setMixpanelDistinctID(_mixpanelDistinctID: {
     mixpanelDistinctID: string | null;
   }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setMixpanelDistinctID');
   }
   setFirebaseAppInstanceID(_firebaseAppInstanceID: {
     firebaseAppInstanceID: string | null;
   }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setFirebaseAppInstanceID');
   }
   setOnesignalID(_onesignalID: { onesignalID: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setOnesignalID');
   }
   setAirshipChannelID(_airshipChannelID: {
     airshipChannelID: string | null;
   }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setAirshipChannelID');
   }
   setMediaSource(_mediaSource: { mediaSource: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setMediaSource');
   }
   setCampaign(_campaign: { campaign: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setCampaign');
   }
   setAdGroup(_adGroup: { adGroup: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setAdGroup');
   }
   setAd(_ad: { ad: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setAd');
   }
   setKeyword(_keyword: { keyword: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setKeyword');
   }
   setCreative(_creative: { creative: string | null }): Promise<void> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockNonReturningFunctionIfEnabled('setCreative');
   }
   canMakePayments(_features?: {
     features?: BILLING_FEATURE[];
   }): Promise<{ canMakePayments: boolean }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    return this.mockReturningFunctionIfEnabled('canMakePayments', { canMakePayments: true});
   }
   beginRefundRequestForActiveEntitlement(): Promise<{
     refundRequestStatus: REFUND_REQUEST_STATUS;
   }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockResult = { refundRequestStatus: REFUND_REQUEST_STATUS.USER_CANCELLED}
+    return this.mockReturningFunctionIfEnabled('beginRefundRequestForActiveEntitlement', mockResult);
   }
   beginRefundRequestForEntitlement(_entitlementInfo: {
     entitlementInfo: PurchasesEntitlementInfo;
   }): Promise<{ refundRequestStatus: REFUND_REQUEST_STATUS }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockResult = { refundRequestStatus: REFUND_REQUEST_STATUS.USER_CANCELLED}
+    return this.mockReturningFunctionIfEnabled('beginRefundRequestForEntitlement', mockResult);
   }
   beginRefundRequestForProduct(_storeProduct: {
     storeProduct: PurchasesStoreProduct;
   }): Promise<{ refundRequestStatus: REFUND_REQUEST_STATUS }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockResult = { refundRequestStatus: REFUND_REQUEST_STATUS.USER_CANCELLED}
+    return this.mockReturningFunctionIfEnabled('beginRefundRequestForProduct', mockResult);
   }
   isConfigured(): Promise<{ isConfigured: boolean }> {
-    return Promise.reject(this.webNotSupportedErrorMessage);
+    const mockResult = { isConfigured: true }
+    return this.mockReturningFunctionIfEnabled('isConfigured', mockResult);
+  }
+
+  // Mock helpers
+
+  private mockEmptyCustomerInfo: CustomerInfo = {
+    entitlements: { all: {}, active: {}},
+    activeSubscriptions: [],
+    allPurchasedProductIdentifiers: [],
+    latestExpirationDate: null,
+    firstSeen: '2023-08-31T15:11:21.445Z',
+    originalAppUserId: 'mock-web-user-id',
+    requestDate: '2023-08-31T15:11:21.445Z',
+    allExpirationDates: {},
+    allPurchaseDates: {},
+    originalApplicationVersion: null,
+    originalPurchaseDate: null,
+    managementURL: null,
+    nonSubscriptionTransactions: []
+  }
+
+  private mockNonReturningFunctionIfEnabled(functionName: string): Promise<void> {
+    if (!this.shouldMockWebResults) {
+      return Promise.reject(this.webNotSupportedErrorMessage);
+    }
+    console.log(`${functionName} called on web with mocking enabled. No-op`);
+    return Promise.resolve();
+  }
+
+  private mockReturningFunctionIfEnabled<T>(functionName: string, returnValue: T): Promise<T> {
+    if (!this.shouldMockWebResults) {
+      return Promise.reject(this.webNotSupportedErrorMessage);
+    }
+    console.log(`${functionName} called on web with mocking enabled. Returning mocked value`);
+    return Promise.resolve(returnValue);
   }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import {WebPlugin} from '@capacitor/core';
+import { WebPlugin } from '@capacitor/core';
 import type {
   BILLING_FEATURE,
   CustomerInfo,
@@ -17,7 +17,7 @@ import type {
   PurchasesStoreProduct,
   ShouldPurchasePromoProductListener,
 } from '@revenuecat/purchases-typescript-internal';
-import {REFUND_REQUEST_STATUS} from '@revenuecat/purchases-typescript-internal'
+import { REFUND_REQUEST_STATUS } from '@revenuecat/purchases-typescript-internal';
 
 import type {
   GetProductOptions,
@@ -52,33 +52,47 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
   setSimulatesAskToBuyInSandbox(_simulatesAskToBuyInSandbox: {
     simulatesAskToBuyInSandbox: boolean;
   }): Promise<void> {
-    return this.mockNonReturningFunctionIfEnabled('setSimulatesAskToBuyInSandbox');
+    return this.mockNonReturningFunctionIfEnabled(
+      'setSimulatesAskToBuyInSandbox',
+    );
   }
   addCustomerInfoUpdateListener(
     _customerInfoUpdateListener: CustomerInfoUpdateListener,
   ): Promise<string> {
-    return this.mockReturningFunctionIfEnabled('addCustomerInfoUpdateListener', 'mock-callback-id');
+    return this.mockReturningFunctionIfEnabled(
+      'addCustomerInfoUpdateListener',
+      'mock-callback-id',
+    );
   }
   removeCustomerInfoUpdateListener(
     _listenerToRemove: string,
   ): Promise<{ wasRemoved: boolean }> {
-    return this.mockReturningFunctionIfEnabled('removeCustomerInfoUpdateListener', { wasRemoved: false});
+    return this.mockReturningFunctionIfEnabled(
+      'removeCustomerInfoUpdateListener',
+      { wasRemoved: false },
+    );
   }
   addShouldPurchasePromoProductListener(
     _shouldPurchasePromoProductListener: ShouldPurchasePromoProductListener,
   ): Promise<string> {
-    return this.mockReturningFunctionIfEnabled('addShouldPurchasePromoProductListener', 'mock-callback-id');
+    return this.mockReturningFunctionIfEnabled(
+      'addShouldPurchasePromoProductListener',
+      'mock-callback-id',
+    );
   }
   removeShouldPurchasePromoProductListener(
     _listenerToRemove: string,
   ): Promise<{ wasRemoved: boolean }> {
-    return this.mockReturningFunctionIfEnabled('removeShouldPurchasePromoProductListener', { wasRemoved: false});
+    return this.mockReturningFunctionIfEnabled(
+      'removeShouldPurchasePromoProductListener',
+      { wasRemoved: false },
+    );
   }
   getOfferings(): Promise<PurchasesOfferings> {
     const mockOfferings: PurchasesOfferings = {
       all: {},
-      current: null
-    }
+      current: null,
+    };
     return this.mockReturningFunctionIfEnabled('getOfferings', mockOfferings);
   }
   getProducts(
@@ -94,7 +108,10 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
       productIdentifier: _options.product.identifier,
       customerInfo: this.mockEmptyCustomerInfo,
     };
-    return this.mockReturningFunctionIfEnabled('purchaseStoreProduct', mockPurchaseResult);
+    return this.mockReturningFunctionIfEnabled(
+      'purchaseStoreProduct',
+      mockPurchaseResult,
+    );
   }
   purchaseDiscountedProduct(
     _options: PurchaseDiscountedProductOptions,
@@ -103,7 +120,10 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
       productIdentifier: _options.product.identifier,
       customerInfo: this.mockEmptyCustomerInfo,
     };
-    return this.mockReturningFunctionIfEnabled('purchaseDiscountedProduct', mockPurchaseResult);
+    return this.mockReturningFunctionIfEnabled(
+      'purchaseDiscountedProduct',
+      mockPurchaseResult,
+    );
   }
   purchasePackage(
     _options: PurchasePackageOptions,
@@ -112,7 +132,10 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
       productIdentifier: _options.aPackage.product.identifier,
       customerInfo: this.mockEmptyCustomerInfo,
     };
-    return this.mockReturningFunctionIfEnabled('purchasePackage', mockPurchaseResult);
+    return this.mockReturningFunctionIfEnabled(
+      'purchasePackage',
+      mockPurchaseResult,
+    );
   }
   purchaseSubscriptionOption(
     _options: PurchaseSubscriptionOptionOptions,
@@ -121,7 +144,10 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
       productIdentifier: _options.subscriptionOption.productId,
       customerInfo: this.mockEmptyCustomerInfo,
     };
-    return this.mockReturningFunctionIfEnabled('purchaseSubscriptionOption', mockPurchaseResult);
+    return this.mockReturningFunctionIfEnabled(
+      'purchaseSubscriptionOption',
+      mockPurchaseResult,
+    );
   }
   purchaseDiscountedPackage(
     _options: PurchaseDiscountedPackageOptions,
@@ -130,24 +156,32 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
       productIdentifier: _options.aPackage.product.identifier,
       customerInfo: this.mockEmptyCustomerInfo,
     };
-    return this.mockReturningFunctionIfEnabled('purchaseDiscountedPackage', mockPurchaseResult);
+    return this.mockReturningFunctionIfEnabled(
+      'purchaseDiscountedPackage',
+      mockPurchaseResult,
+    );
   }
   restorePurchases(): Promise<{ customerInfo: CustomerInfo }> {
-    const mockResponse = { customerInfo: this.mockEmptyCustomerInfo }
-    return this.mockReturningFunctionIfEnabled('restorePurchases', mockResponse);
+    const mockResponse = { customerInfo: this.mockEmptyCustomerInfo };
+    return this.mockReturningFunctionIfEnabled(
+      'restorePurchases',
+      mockResponse,
+    );
   }
   getAppUserID(): Promise<{ appUserID: string }> {
-    return this.mockReturningFunctionIfEnabled('getAppUserID', { appUserID: 'test-web-user-id'});
+    return this.mockReturningFunctionIfEnabled('getAppUserID', {
+      appUserID: 'test-web-user-id',
+    });
   }
   logIn(_appUserID: { appUserID: string }): Promise<LogInResult> {
     const mockLogInResult: LogInResult = {
       customerInfo: this.mockEmptyCustomerInfo,
       created: false,
-    }
+    };
     return this.mockReturningFunctionIfEnabled('logIn', mockLogInResult);
   }
   logOut(): Promise<{ customerInfo: CustomerInfo }> {
-    const mockResponse = { customerInfo: this.mockEmptyCustomerInfo }
+    const mockResponse = { customerInfo: this.mockEmptyCustomerInfo };
     return this.mockReturningFunctionIfEnabled('logOut', mockResponse);
   }
   setLogLevel(_level: { level: LOG_LEVEL }): Promise<void> {
@@ -157,7 +191,7 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
     return this.mockNonReturningFunctionIfEnabled('setLogHandler');
   }
   getCustomerInfo(): Promise<{ customerInfo: CustomerInfo }> {
-    const mockResponse = { customerInfo: this.mockEmptyCustomerInfo }
+    const mockResponse = { customerInfo: this.mockEmptyCustomerInfo };
     return this.mockReturningFunctionIfEnabled('getCustomerInfo', mockResponse);
   }
   syncPurchases(): Promise<void> {
@@ -166,27 +200,39 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
   syncObserverModeAmazonPurchase(
     _options: SyncObserverModeAmazonPurchaseOptions,
   ): Promise<void> {
-    return this.mockNonReturningFunctionIfEnabled('syncObserverModeAmazonPurchase');
+    return this.mockNonReturningFunctionIfEnabled(
+      'syncObserverModeAmazonPurchase',
+    );
   }
   enableAdServicesAttributionTokenCollection(): Promise<void> {
-    return this.mockNonReturningFunctionIfEnabled('enableAdServicesAttributionTokenCollection');
+    return this.mockNonReturningFunctionIfEnabled(
+      'enableAdServicesAttributionTokenCollection',
+    );
   }
   isAnonymous(): Promise<{ isAnonymous: boolean }> {
-    const mockResponse = { isAnonymous: false }
+    const mockResponse = { isAnonymous: false };
     return this.mockReturningFunctionIfEnabled('isAnonymous', mockResponse);
   }
   checkTrialOrIntroductoryPriceEligibility(_productIdentifiers: {
     productIdentifiers: string[];
   }): Promise<{ [productId: string]: IntroEligibility }> {
-    return this.mockReturningFunctionIfEnabled('checkTrialOrIntroductoryPriceEligibility', {});
+    return this.mockReturningFunctionIfEnabled(
+      'checkTrialOrIntroductoryPriceEligibility',
+      {},
+    );
   }
   getPromotionalOffer(
     _options: GetPromotionalOfferOptions,
   ): Promise<PurchasesPromotionalOffer | undefined> {
-    return this.mockReturningFunctionIfEnabled('getPromotionalOffer', undefined);
+    return this.mockReturningFunctionIfEnabled(
+      'getPromotionalOffer',
+      undefined,
+    );
   }
   invalidateCustomerInfoCache(): Promise<void> {
-    return this.mockNonReturningFunctionIfEnabled('invalidateCustomerInfoCache');
+    return this.mockNonReturningFunctionIfEnabled(
+      'invalidateCustomerInfoCache',
+    );
   }
   presentCodeRedemptionSheet(): Promise<void> {
     return this.mockNonReturningFunctionIfEnabled('presentCodeRedemptionSheet');
@@ -268,35 +314,52 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
   canMakePayments(_features?: {
     features?: BILLING_FEATURE[];
   }): Promise<{ canMakePayments: boolean }> {
-    return this.mockReturningFunctionIfEnabled('canMakePayments', { canMakePayments: true});
+    return this.mockReturningFunctionIfEnabled('canMakePayments', {
+      canMakePayments: true,
+    });
   }
   beginRefundRequestForActiveEntitlement(): Promise<{
     refundRequestStatus: REFUND_REQUEST_STATUS;
   }> {
-    const mockResult = { refundRequestStatus: REFUND_REQUEST_STATUS.USER_CANCELLED}
-    return this.mockReturningFunctionIfEnabled('beginRefundRequestForActiveEntitlement', mockResult);
+    const mockResult = {
+      refundRequestStatus: REFUND_REQUEST_STATUS.USER_CANCELLED,
+    };
+    return this.mockReturningFunctionIfEnabled(
+      'beginRefundRequestForActiveEntitlement',
+      mockResult,
+    );
   }
   beginRefundRequestForEntitlement(_entitlementInfo: {
     entitlementInfo: PurchasesEntitlementInfo;
   }): Promise<{ refundRequestStatus: REFUND_REQUEST_STATUS }> {
-    const mockResult = { refundRequestStatus: REFUND_REQUEST_STATUS.USER_CANCELLED}
-    return this.mockReturningFunctionIfEnabled('beginRefundRequestForEntitlement', mockResult);
+    const mockResult = {
+      refundRequestStatus: REFUND_REQUEST_STATUS.USER_CANCELLED,
+    };
+    return this.mockReturningFunctionIfEnabled(
+      'beginRefundRequestForEntitlement',
+      mockResult,
+    );
   }
   beginRefundRequestForProduct(_storeProduct: {
     storeProduct: PurchasesStoreProduct;
   }): Promise<{ refundRequestStatus: REFUND_REQUEST_STATUS }> {
-    const mockResult = { refundRequestStatus: REFUND_REQUEST_STATUS.USER_CANCELLED}
-    return this.mockReturningFunctionIfEnabled('beginRefundRequestForProduct', mockResult);
+    const mockResult = {
+      refundRequestStatus: REFUND_REQUEST_STATUS.USER_CANCELLED,
+    };
+    return this.mockReturningFunctionIfEnabled(
+      'beginRefundRequestForProduct',
+      mockResult,
+    );
   }
   isConfigured(): Promise<{ isConfigured: boolean }> {
-    const mockResult = { isConfigured: true }
+    const mockResult = { isConfigured: true };
     return this.mockReturningFunctionIfEnabled('isConfigured', mockResult);
   }
 
   // Mock helpers
 
   private mockEmptyCustomerInfo: CustomerInfo = {
-    entitlements: { all: {}, active: {}},
+    entitlements: { all: {}, active: {} },
     activeSubscriptions: [],
     allPurchasedProductIdentifiers: [],
     latestExpirationDate: null,
@@ -308,10 +371,12 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
     originalApplicationVersion: null,
     originalPurchaseDate: null,
     managementURL: null,
-    nonSubscriptionTransactions: []
-  }
+    nonSubscriptionTransactions: [],
+  };
 
-  private mockNonReturningFunctionIfEnabled(functionName: string): Promise<void> {
+  private mockNonReturningFunctionIfEnabled(
+    functionName: string,
+  ): Promise<void> {
     if (!this.shouldMockWebResults) {
       return Promise.reject(this.webNotSupportedErrorMessage);
     }
@@ -319,11 +384,16 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
     return Promise.resolve();
   }
 
-  private mockReturningFunctionIfEnabled<T>(functionName: string, returnValue: T): Promise<T> {
+  private mockReturningFunctionIfEnabled<T>(
+    functionName: string,
+    returnValue: T,
+  ): Promise<T> {
     if (!this.shouldMockWebResults) {
       return Promise.reject(this.webNotSupportedErrorMessage);
     }
-    console.log(`${functionName} called on web with mocking enabled. Returning mocked value`);
+    console.log(
+      `${functionName} called on web with mocking enabled. Returning mocked value`,
+    );
     return Promise.resolve(returnValue);
   }
 }


### PR DESCRIPTION
This adds a new method to the plugin: `setMockWebResults`. If you enable it, you will receive some mocked data when using the plugin on the web. Nothing will be affected in the android/ios versions.
