### PR TITLE
Fix release job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,7 @@ jobs:
       - checkout
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
+      - yarn-dependencies-mac
       - revenuecat/trust-github-key
       - copy-npm-rc
       - run:


### PR DESCRIPTION
This fixes the release job in CircleCI. It was failing during `npm publish` because it was trying to build the project but the yarn dependencies were not installed