### PR TITLE
Fix hybrid common upgrades automation

### DIFF
--- a/RevenueCatPurchasesCapacitor.podspec
+++ b/RevenueCatPurchasesCapacitor.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'PurchasesHybridCommon', '6.1.3'
+  s.dependency 'PurchasesHybridCommon', '6.2.0'
   s.swift_version = '5.1'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common:6.1.3'
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common:6.2.0'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -193,7 +193,7 @@ end
 
 def get_phc_version
   Dir.chdir(get_root_folder) do
-    return (sh "cat RevenueCatPurchasesCapacitor.podspec | grep \"\'PurchasesHybridCommon\', \'\" | awk \'{print($3)}\' | sed \"s/\'//g\"").strip
+    return (sh "cat RevenueCatPurchasesCapacitor.podspec | grep \"'PurchasesHybridCommon', '\" | awk '{print($3)}' | sed \"s/\'//g\"").strip
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,7 +5,7 @@ files_with_version_number = {
     './android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt' => ['PLUGIN_VERSION = "{x}"']
 }
 files_to_update_phc_version = {
-    'RevenueCatPurchasesCapacitor.podspec' => ['"PurchasesHybridCommon", \'{x}\''],
+    'RevenueCatPurchasesCapacitor.podspec' => ["'PurchasesHybridCommon', \'{x}\'"],
     'android/build.gradle' => ['com.revenuecat.purchases:purchases-hybrid-common:{x}'],
     'package.json' => ['"@revenuecat/purchases-typescript-internal-esm": "{x}"']
 }
@@ -193,7 +193,7 @@ end
 
 def get_phc_version
   Dir.chdir(get_root_folder) do
-    return (sh "cat RevenueCatPurchasesCapacitor.podspec | grep \'\"PurchasesHybridCommon\", \' | awk \'{print($3)}\' | sed \"s/\'//g\"").strip
+    return (sh "cat RevenueCatPurchasesCapacitor.podspec | grep \"\'PurchasesHybridCommon\', \'\" | awk \'{print($3)}\' | sed \"s/\'//g\"").strip
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,7 +5,7 @@ files_with_version_number = {
     './android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt' => ['PLUGIN_VERSION = "{x}"']
 }
 files_to_update_phc_version = {
-    'RevenueCatPurchasesCapacitor.podspec' => ["'PurchasesHybridCommon', \'{x}\'"],
+    'RevenueCatPurchasesCapacitor.podspec' => ["'PurchasesHybridCommon', '{x}'"],
     'android/build.gradle' => ['com.revenuecat.purchases:purchases-hybrid-common:{x}'],
     'package.json' => ['"@revenuecat/purchases-typescript-internal-esm": "{x}"']
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     }
   },
   "dependencies": {
-    "@revenuecat/purchases-typescript-internal-esm": "6.1.3"
+    "@revenuecat/purchases-typescript-internal-esm": "6.2.0"
   }
 }


### PR DESCRIPTION
We were using single quotes for the podspec file instead of double quotes. That was making the automation to update hybrid common fail. This fixes that and updates to PHC 6.2.0