### PR TITLE
`CI`: disable `prepare-next-version`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,20 +130,6 @@ jobs:
       - run: yarn build
       - run: yarn lint
 
-  prepare-next-version:
-    description: "Creates a PR with the new snapshot version"
-    docker:
-      - image: cimg/ruby:3.1.2
-    steps:
-      - checkout
-      - revenuecat/install-gem-unix-dependencies:
-          cache-version: v1
-      - revenuecat/trust-github-key
-      - revenuecat/setup-git-credentials
-      - run:
-          name: Prepare next version
-          command: bundle exec fastlane prepare_next_version
-
   make-release:
     description: "Publishes the new version and creates a github release"
     <<: *base-mac-job
@@ -232,14 +218,6 @@ workflows:
   danger:
     jobs:
       - revenuecat/danger
-
-  snapshot-bump:
-    when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-    jobs:
-      - prepare-next-version:
-          <<: *only-main-branch
 
   weekly-run-workflow:
     when:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -80,17 +80,6 @@ lane :github_release do |options|
   )
 end
 
-desc "Creates PR changing version to next minor adding a -SNAPSHOT suffix"
-lane :prepare_next_version do |options|
-  create_next_snapshot_version(
-    current_version: current_version_number,
-    repo_name: repo_name,
-    github_pr_token: ENV["GITHUB_PULL_REQUEST_API_TOKEN"],
-    files_to_update: files_with_version_number,
-    files_to_update_without_prerelease_modifiers: {}
-  )
-end
-
 desc "Creates GitHub release and publishes package"
 lane :release do |options|
   version_number = current_version_number


### PR DESCRIPTION
As discussed, these provide little value in the hybrids and instead create unnecessary busy work.
