### PR TITLE
Remove "Error x, " prefix from error messages on iOS

### DIFF
--- a/ios/Plugin/PluginHelperExtensions.swift
+++ b/ios/Plugin/PluginHelperExtensions.swift
@@ -17,7 +17,7 @@ internal extension PurchasesPlugin {
     }
 
     func rejectWithErrorContainer(_ call: CAPPluginCall, error: ErrorContainer) {
-        call.reject("Error \(error.code), \(error.message)", "\(error.code)", error.error)
+        call.reject("\(error.message)", "\(error.code)", error.error)
     }
 
     func getCompletionBlockHandler(_ call: CAPPluginCall,


### PR DESCRIPTION
Small update just to remove the "Error x, " prefix on the error.message property returned from the plugin on iOS.

For example, "Error 1, Purchase was cancelled." becomes "Purchase was cancelled."

This matches what the Android version returns.