### PR TITLE
Fix iOS PHC version when running tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,6 +6,7 @@ files_with_version_number = {
 }
 files_to_update_phc_version = {
     'RevenueCatPurchasesCapacitor.podspec' => ["'PurchasesHybridCommon', '{x}'"],
+    'ios/Podfile' => ["'PurchasesHybridCommon', '{x}'"],
     'android/build.gradle' => ['com.revenuecat.purchases:purchases-hybrid-common:{x}'],
     'package.json' => ['"@revenuecat/purchases-typescript-internal-esm": "{x}"']
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,7 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'PurchasesHybridCommon'
+  pod 'PurchasesHybridCommon', '9.9.0'
 end
 
 target 'Plugin' do


### PR DESCRIPTION
Tests were running against the latest version of PHC. Instead, we should be using the same version as the version used by the plugin.
