### PR TITLE
Adds`Purchases.getCurrentOfferingForPlacement(placementID)` and `Purchases.syncAttributesAndOfferingsIfNeeded()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ This plugin is based on [CapGo's Capacitor plugin](https://www.npmjs.com/package
 * [`addCustomerInfoUpdateListener(...)`](#addcustomerinfoupdatelistener)
 * [`removeCustomerInfoUpdateListener(...)`](#removecustomerinfoupdatelistener)
 * [`getOfferings()`](#getofferings)
+* [`getCurrentOfferingForPlacement(...)`](#getcurrentofferingforplacement)
+* [`syncAttributesAndOfferingsIfNeeded()`](#syncattributesandofferingsifneeded)
 * [`getProducts(...)`](#getproducts)
 * [`purchaseStoreProduct(...)`](#purchasestoreproduct)
 * [`purchaseDiscountedProduct(...)`](#purchasediscountedproduct)
@@ -219,6 +221,36 @@ getOfferings() => Promise<PurchasesOfferings>
 ```
 
 Gets the map of entitlements -&gt; offerings -&gt; products
+
+**Returns:** <code>Promise&lt;<a href="#purchasesofferings">PurchasesOfferings</a>&gt;</code>
+
+--------------------
+
+
+### getCurrentOfferingForPlacement(...)
+
+```typescript
+getCurrentOfferingForPlacement(placementIdentifier: string) => Promise<PurchasesOffering | null>
+```
+
+WORDS
+
+| Param                     | Type                |
+| ------------------------- | ------------------- |
+| **`placementIdentifier`** | <code>string</code> |
+
+**Returns:** <code>Promise&lt;<a href="#purchasesoffering">PurchasesOffering</a> | null&gt;</code>
+
+--------------------
+
+
+### syncAttributesAndOfferingsIfNeeded()
+
+```typescript
+syncAttributesAndOfferingsIfNeeded() => Promise<PurchasesOfferings>
+```
+
+WORDS
 
 **Returns:** <code>Promise&lt;<a href="#purchasesofferings">PurchasesOfferings</a>&gt;</code>
 
@@ -1134,32 +1166,34 @@ For more info see https://docs.revenuecat.com/docs/entitlements
 Contains information about the product available for the user to purchase.
 For more info see https://docs.revenuecat.com/docs/entitlements
 
-| Prop                     | Type                                                                    | Description                                                                               |
-| ------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| **`identifier`**         | <code>string</code>                                                     | Unique identifier for this package. Can be one a predefined package type or a custom one. |
-| **`packageType`**        | <code><a href="#package_type">PACKAGE_TYPE</a></code>                   | Package type for the product. Will be one of [PACKAGE_TYPE].                              |
-| **`product`**            | <code><a href="#purchasesstoreproduct">PurchasesStoreProduct</a></code> | Product assigned to this package.                                                         |
-| **`offeringIdentifier`** | <code>string</code>                                                     | Offering this package belongs to.                                                         |
+| Prop                           | Type                                                                          | Description                                                                                                              |
+| ------------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **`identifier`**               | <code>string</code>                                                           | Unique identifier for this package. Can be one a predefined package type or a custom one.                                |
+| **`packageType`**              | <code><a href="#package_type">PACKAGE_TYPE</a></code>                         | Package type for the product. Will be one of [PACKAGE_TYPE].                                                             |
+| **`product`**                  | <code><a href="#purchasesstoreproduct">PurchasesStoreProduct</a></code>       | Product assigned to this package.                                                                                        |
+| **`offeringIdentifier`**       | <code>string</code>                                                           | Offering this package belongs to.                                                                                        |
+| **`presentedOfferingContext`** | <code><a href="#presentedofferingcontext">PresentedOfferingContext</a></code> | Offering context this package belongs to. Null if not using offerings or if fetched directly from store via getProducts. |
 
 
 #### PurchasesStoreProduct
 
-| Prop                              | Type                                                                        | Description                                                                                                                                                                                                                             |
-| --------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`identifier`**                  | <code>string</code>                                                         | Product Id.                                                                                                                                                                                                                             |
-| **`description`**                 | <code>string</code>                                                         | Description of the product.                                                                                                                                                                                                             |
-| **`title`**                       | <code>string</code>                                                         | Title of the product.                                                                                                                                                                                                                   |
-| **`price`**                       | <code>number</code>                                                         | <a href="#price">Price</a> of the product in the local currency. Contains the price value of defaultOption for Google Play.                                                                                                             |
-| **`priceString`**                 | <code>string</code>                                                         | Formatted price of the item, including its currency sign. Contains the formatted price value of defaultOption for Google Play.                                                                                                          |
-| **`currencyCode`**                | <code>string</code>                                                         | Currency code for price and original price. Contains the currency code value of defaultOption for Google Play.                                                                                                                          |
-| **`introPrice`**                  | <code><a href="#purchasesintroprice">PurchasesIntroPrice</a> \| null</code> | Introductory price.                                                                                                                                                                                                                     |
-| **`discounts`**                   | <code>PurchasesStoreProductDiscount[] \| null</code>                        | Collection of discount offers for a product. Null for Android.                                                                                                                                                                          |
-| **`productCategory`**             | <code><a href="#product_category">PRODUCT_CATEGORY</a> \| null</code>       | Product category.                                                                                                                                                                                                                       |
-| **`productType`**                 | <code><a href="#product_type">PRODUCT_TYPE</a></code>                       | The specific type of subscription or one time purchase this product represents. Important: In iOS, if using StoreKit 1, we cannot determine the type.                                                                                   |
-| **`subscriptionPeriod`**          | <code>string \| null</code>                                                 | Subscription period, specified in ISO 8601 format. For example, P1W equates to one week, P1M equates to one month, P3M equates to three months, P6M equates to six months, and P1Y equates to one year. Note: Not available for Amazon. |
-| **`defaultOption`**               | <code><a href="#subscriptionoption">SubscriptionOption</a> \| null</code>   | Default subscription option for a product. Google Play only.                                                                                                                                                                            |
-| **`subscriptionOptions`**         | <code>SubscriptionOption[] \| null</code>                                   | Collection of subscription options for a product. Google Play only.                                                                                                                                                                     |
-| **`presentedOfferingIdentifier`** | <code>string \| null</code>                                                 | Offering identifier the store product was presented from. Null if not using offerings or if fetched directly from store via getProducts.                                                                                                |
+| Prop                              | Type                                                                                  | Description                                                                                                                                                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`identifier`**                  | <code>string</code>                                                                   | Product Id.                                                                                                                                                                                                                             |
+| **`description`**                 | <code>string</code>                                                                   | Description of the product.                                                                                                                                                                                                             |
+| **`title`**                       | <code>string</code>                                                                   | Title of the product.                                                                                                                                                                                                                   |
+| **`price`**                       | <code>number</code>                                                                   | <a href="#price">Price</a> of the product in the local currency. Contains the price value of defaultOption for Google Play.                                                                                                             |
+| **`priceString`**                 | <code>string</code>                                                                   | Formatted price of the item, including its currency sign. Contains the formatted price value of defaultOption for Google Play.                                                                                                          |
+| **`currencyCode`**                | <code>string</code>                                                                   | Currency code for price and original price. Contains the currency code value of defaultOption for Google Play.                                                                                                                          |
+| **`introPrice`**                  | <code><a href="#purchasesintroprice">PurchasesIntroPrice</a> \| null</code>           | Introductory price.                                                                                                                                                                                                                     |
+| **`discounts`**                   | <code>PurchasesStoreProductDiscount[] \| null</code>                                  | Collection of discount offers for a product. Null for Android.                                                                                                                                                                          |
+| **`productCategory`**             | <code><a href="#product_category">PRODUCT_CATEGORY</a> \| null</code>                 | Product category.                                                                                                                                                                                                                       |
+| **`productType`**                 | <code><a href="#product_type">PRODUCT_TYPE</a></code>                                 | The specific type of subscription or one time purchase this product represents. Important: In iOS, if using StoreKit 1, we cannot determine the type.                                                                                   |
+| **`subscriptionPeriod`**          | <code>string \| null</code>                                                           | Subscription period, specified in ISO 8601 format. For example, P1W equates to one week, P1M equates to one month, P3M equates to three months, P6M equates to six months, and P1Y equates to one year. Note: Not available for Amazon. |
+| **`defaultOption`**               | <code><a href="#subscriptionoption">SubscriptionOption</a> \| null</code>             | Default subscription option for a product. Google Play only.                                                                                                                                                                            |
+| **`subscriptionOptions`**         | <code>SubscriptionOption[] \| null</code>                                             | Collection of subscription options for a product. Google Play only.                                                                                                                                                                     |
+| **`presentedOfferingIdentifier`** | <code>string \| null</code>                                                           | Offering identifier the store product was presented from. Null if not using offerings or if fetched directly from store via getProducts.                                                                                                |
+| **`presentedOfferingContext`**    | <code><a href="#presentedofferingcontext">PresentedOfferingContext</a> \| null</code> | Offering context this package belongs to. Null if not using offerings or if fetched directly from store via getProducts.                                                                                                                |
 
 
 #### PurchasesIntroPrice
@@ -1192,20 +1226,21 @@ For more info see https://docs.revenuecat.com/docs/entitlements
 Contains all details associated with a SubscriptionOption
 Used only for Google
 
-| Prop                              | Type                                                          | Description                                                                                                                                                                                                                                                                                                                                |
-| --------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **`id`**                          | <code>string</code>                                           | Identifier of the subscription option If this <a href="#subscriptionoption">SubscriptionOption</a> represents a base plan, this will be the basePlanId. If it represents an offer, it will be {basePlanId}:{offerId}                                                                                                                       |
-| **`storeProductId`**              | <code>string</code>                                           | Identifier of the StoreProduct associated with this SubscriptionOption This will be {subId}:{basePlanId}                                                                                                                                                                                                                                   |
-| **`productId`**                   | <code>string</code>                                           | Identifer of the subscription associated with this SubscriptionOption This will be {subId}                                                                                                                                                                                                                                                 |
-| **`pricingPhases`**               | <code>PricingPhase[]</code>                                   | Pricing phases defining a user's payment plan for the product over time.                                                                                                                                                                                                                                                                   |
-| **`tags`**                        | <code>string[]</code>                                         | Tags defined on the base plan or offer. Empty for Amazon.                                                                                                                                                                                                                                                                                  |
-| **`isBasePlan`**                  | <code>boolean</code>                                          | True if this <a href="#subscriptionoption">SubscriptionOption</a> represents a subscription base plan (rather than an offer).                                                                                                                                                                                                              |
-| **`billingPeriod`**               | <code><a href="#period">Period</a> \| null</code>             | The subscription period of fullPricePhase (after free and intro trials).                                                                                                                                                                                                                                                                   |
-| **`isPrepaid`**                   | <code>boolean</code>                                          | True if the subscription is pre-paid.                                                                                                                                                                                                                                                                                                      |
-| **`fullPricePhase`**              | <code><a href="#pricingphase">PricingPhase</a> \| null</code> | The full price <a href="#pricingphase">PricingPhase</a> of the subscription. Looks for the last price phase of the <a href="#subscriptionoption">SubscriptionOption</a>.                                                                                                                                                                   |
-| **`freePhase`**                   | <code><a href="#pricingphase">PricingPhase</a> \| null</code> | The free trial <a href="#pricingphase">PricingPhase</a> of the subscription. Looks for the first pricing phase of the <a href="#subscriptionoption">SubscriptionOption</a> where amountMicros is 0. There can be a freeTrialPhase and an introductoryPhase in the same <a href="#subscriptionoption">SubscriptionOption</a>.               |
-| **`introPhase`**                  | <code><a href="#pricingphase">PricingPhase</a> \| null</code> | The intro trial <a href="#pricingphase">PricingPhase</a> of the subscription. Looks for the first pricing phase of the <a href="#subscriptionoption">SubscriptionOption</a> where amountMicros is greater than 0. There can be a freeTrialPhase and an introductoryPhase in the same <a href="#subscriptionoption">SubscriptionOption</a>. |
-| **`presentedOfferingIdentifier`** | <code>string \| null</code>                                   | Offering identifier the subscription option was presented from                                                                                                                                                                                                                                                                             |
+| Prop                              | Type                                                                                  | Description                                                                                                                                                                                                                                                                                                                                |
+| --------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`id`**                          | <code>string</code>                                                                   | Identifier of the subscription option If this <a href="#subscriptionoption">SubscriptionOption</a> represents a base plan, this will be the basePlanId. If it represents an offer, it will be {basePlanId}:{offerId}                                                                                                                       |
+| **`storeProductId`**              | <code>string</code>                                                                   | Identifier of the StoreProduct associated with this SubscriptionOption This will be {subId}:{basePlanId}                                                                                                                                                                                                                                   |
+| **`productId`**                   | <code>string</code>                                                                   | Identifer of the subscription associated with this SubscriptionOption This will be {subId}                                                                                                                                                                                                                                                 |
+| **`pricingPhases`**               | <code>PricingPhase[]</code>                                                           | Pricing phases defining a user's payment plan for the product over time.                                                                                                                                                                                                                                                                   |
+| **`tags`**                        | <code>string[]</code>                                                                 | Tags defined on the base plan or offer. Empty for Amazon.                                                                                                                                                                                                                                                                                  |
+| **`isBasePlan`**                  | <code>boolean</code>                                                                  | True if this <a href="#subscriptionoption">SubscriptionOption</a> represents a subscription base plan (rather than an offer).                                                                                                                                                                                                              |
+| **`billingPeriod`**               | <code><a href="#period">Period</a> \| null</code>                                     | The subscription period of fullPricePhase (after free and intro trials).                                                                                                                                                                                                                                                                   |
+| **`isPrepaid`**                   | <code>boolean</code>                                                                  | True if the subscription is pre-paid.                                                                                                                                                                                                                                                                                                      |
+| **`fullPricePhase`**              | <code><a href="#pricingphase">PricingPhase</a> \| null</code>                         | The full price <a href="#pricingphase">PricingPhase</a> of the subscription. Looks for the last price phase of the <a href="#subscriptionoption">SubscriptionOption</a>.                                                                                                                                                                   |
+| **`freePhase`**                   | <code><a href="#pricingphase">PricingPhase</a> \| null</code>                         | The free trial <a href="#pricingphase">PricingPhase</a> of the subscription. Looks for the first pricing phase of the <a href="#subscriptionoption">SubscriptionOption</a> where amountMicros is 0. There can be a freeTrialPhase and an introductoryPhase in the same <a href="#subscriptionoption">SubscriptionOption</a>.               |
+| **`introPhase`**                  | <code><a href="#pricingphase">PricingPhase</a> \| null</code>                         | The intro trial <a href="#pricingphase">PricingPhase</a> of the subscription. Looks for the first pricing phase of the <a href="#subscriptionoption">SubscriptionOption</a> where amountMicros is greater than 0. There can be a freeTrialPhase and an introductoryPhase in the same <a href="#subscriptionoption">SubscriptionOption</a>. |
+| **`presentedOfferingIdentifier`** | <code>string \| null</code>                                                           | Offering identifier the subscription option was presented from                                                                                                                                                                                                                                                                             |
+| **`presentedOfferingContext`**    | <code><a href="#presentedofferingcontext">PresentedOfferingContext</a> \| null</code> | Offering context this package belongs to. Null if not using offerings or if fetched directly from store via getProducts.                                                                                                                                                                                                                   |
 
 
 #### PricingPhase
@@ -1241,6 +1276,27 @@ Contains all the details associated with a <a href="#price">Price</a>
 | **`formatted`**    | <code>string</code> | Formatted price of the item, including its currency sign. For example $3.00                                                                                                                                                                              |
 | **`amountMicros`** | <code>number</code> | <a href="#price">Price</a> in micro-units, where 1,000,000 micro-units equal one unit of the currency. For example, if price is "€7.99", price_amount_micros is 7,990,000. This value represents the localized, rounded price for a particular currency. |
 | **`currencyCode`** | <code>string</code> | Returns ISO 4217 currency code for price and original price. For example, if price is specified in British pounds sterling, price_currency_code is "GBP". If currency code cannot be determined, currency symbol is returned.                            |
+
+
+#### PresentedOfferingContext
+
+Contains data about the context in which an offering was presented.
+
+| Prop                      | Type                                                                                                    | Description                                                 |
+| ------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| **`offeringIdentifier`**  | <code>string</code>                                                                                     | The identifier of the offering used to obtain this object.  |
+| **`placementIdentifier`** | <code>string \| null</code>                                                                             | The identifier of the placement used to obtain this object. |
+| **`targetingContext`**    | <code><a href="#presentedofferingtargetingcontext">PresentedOfferingTargetingContext</a> \| null</code> | The revision of the targeting used to obtain this object.   |
+
+
+#### PresentedOfferingTargetingContext
+
+Contains data about the context in which an offering was presented.
+
+| Prop           | Type                | Description                                                |
+| -------------- | ------------------- | ---------------------------------------------------------- |
+| **`revision`** | <code>number</code> | The revision of the targeting used to obtain this object.  |
+| **`ruleId`**   | <code>string</code> | The rule id from the targeting used to obtain this object. |
 
 
 #### GetProductOptions

--- a/example/purchase-tester/src/components/FunctionTesterContainer.tsx
+++ b/example/purchase-tester/src/components/FunctionTesterContainer.tsx
@@ -1,156 +1,200 @@
 import './FunctionTesterContainer.css';
-import {IonButton, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle} from "@ionic/react";
-import React, {useEffect, useState} from "react";
+import {
+  IonButton,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardSubtitle,
+  IonCardTitle,
+} from '@ionic/react';
+import React, { useEffect, useState } from 'react';
 import {
   LOG_LEVEL,
   PRODUCT_CATEGORY,
   PurchaseDiscountedPackageOptions,
-  Purchases
-} from "@revenuecat/purchases-capacitor";
+  Purchases,
+} from '@revenuecat/purchases-capacitor';
 
-import {REVENUECAT_API_KEY} from "../constants";
-import {ENTITLEMENT_VERIFICATION_MODE, IN_APP_MESSAGE_TYPE} from "@revenuecat/purchases-typescript-internal-esm";
+import { REVENUECAT_API_KEY } from '../constants';
+import {
+  ENTITLEMENT_VERIFICATION_MODE,
+  IN_APP_MESSAGE_TYPE,
+} from '@revenuecat/purchases-typescript-internal-esm';
 
-interface ContainerProps { }
+interface ContainerProps {}
 
 const FunctionTesterContainer: React.FC<ContainerProps> = () => {
   useEffect(() => {
     (async function () {
-      await Purchases.setMockWebResults({ shouldMockWebResults: true })
+      await Purchases.setMockWebResults({ shouldMockWebResults: true });
       await Purchases.setLogLevel({ level: LOG_LEVEL.VERBOSE });
     })();
   }, []);
 
-  const [lastFunctionExecuted, setLastFunctionExecuted] = useState("No RC function with result executed");
-  const [lastFunctionContent, setLastFunctionContent] = useState("No content");
+  const [lastFunctionExecuted, setLastFunctionExecuted] = useState(
+    'No RC function with result executed',
+  );
+  const [lastFunctionContent, setLastFunctionContent] = useState('No content');
   const [finishTransactions, setFinishTransactions] = useState(true);
-  const [simulatesAskToBuyInSandbox, setSimulatesAskToBuyInSandbox] = useState(false);
+  const [simulatesAskToBuyInSandbox, setSimulatesAskToBuyInSandbox] =
+    useState(false);
 
   const prettifyJson = (objectToPrettify: object) => {
     return JSON.stringify(objectToPrettify, null, 2);
-  }
+  };
 
-  const updateLastFunction = (lastFunctionExecuted: string, lastFunctionContent: object | string) => {
+  const updateLastFunction = (
+    lastFunctionExecuted: string,
+    lastFunctionContent: object | string,
+  ) => {
     setLastFunctionExecuted(lastFunctionExecuted);
     if (typeof lastFunctionContent == 'string') {
       setLastFunctionContent(lastFunctionContent);
     } else {
       setLastFunctionContent(prettifyJson(lastFunctionContent));
     }
-  }
+  };
 
   const updateLastFunctionWithoutContent = (lastFunctionExecuted: string) => {
     setLastFunctionExecuted(lastFunctionExecuted);
     setLastFunctionContent(`${lastFunctionExecuted} does not return content`);
-  }
+  };
 
   const getPackageAndOfferForCurrentOfferingFirstPackage = async () => {
     const offerings = await Purchases.getOfferings();
-    const packageToBuy = offerings.current
-      && offerings.current.availablePackages
-      && offerings.current.availablePackages[0];
+    const packageToBuy =
+      offerings.current &&
+      offerings.current.availablePackages &&
+      offerings.current.availablePackages[0];
     if (packageToBuy == null) {
-      return Promise.reject("No package found in current offering");
+      return Promise.reject('No package found in current offering');
     }
     const productToBuy = packageToBuy.product;
-    const discountToApply = productToBuy.discounts && productToBuy.discounts[0]
+    const discountToApply = productToBuy.discounts && productToBuy.discounts[0];
     if (discountToApply == null) {
-      return Promise.reject("Package did not have any discounts to apply");
+      return Promise.reject('Package did not have any discounts to apply');
     }
-    const promotionalOffer = await Purchases.getPromotionalOffer(
-      { product: productToBuy, discount: discountToApply }
-    )
+    const promotionalOffer = await Purchases.getPromotionalOffer({
+      product: productToBuy,
+      discount: discountToApply,
+    });
     if (promotionalOffer == null) {
-      return Promise.reject("Could not obtain promotional offer");
+      return Promise.reject('Could not obtain promotional offer');
     }
-    const options: PurchaseDiscountedPackageOptions = { aPackage: packageToBuy, discount: promotionalOffer };
+    const options: PurchaseDiscountedPackageOptions = {
+      aPackage: packageToBuy,
+      discount: promotionalOffer,
+    };
     return options;
-  }
+  };
 
   const configure = async () => {
     await Purchases.configure({
       apiKey: REVENUECAT_API_KEY,
-      entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL
+      entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL,
     });
-    await Purchases.addCustomerInfoUpdateListener((customerInfo) => {
-      console.log(`Received customer info in listener: ${prettifyJson(customerInfo)}`);
+    await Purchases.addCustomerInfoUpdateListener(customerInfo => {
+      console.log(
+        `Received customer info in listener: ${prettifyJson(customerInfo)}`,
+      );
     });
-    updateLastFunctionWithoutContent("configure");
+    updateLastFunctionWithoutContent('configure');
   };
 
   const changeFinishTransactions = async () => {
     const newFinishTransactions = !finishTransactions;
-    await Purchases.setFinishTransactions({ finishTransactions: newFinishTransactions });
+    await Purchases.setFinishTransactions({
+      finishTransactions: newFinishTransactions,
+    });
     setFinishTransactions(newFinishTransactions);
-    updateLastFunctionWithoutContent("setFinishTransactions");
+    updateLastFunctionWithoutContent('setFinishTransactions');
   };
 
   const changeSimulatesAskToBuyInSandbox = async () => {
     const newSimulatesAskToBuyInSandbox = !simulatesAskToBuyInSandbox;
-    await Purchases.setSimulatesAskToBuyInSandbox({ simulatesAskToBuyInSandbox: newSimulatesAskToBuyInSandbox });
+    await Purchases.setSimulatesAskToBuyInSandbox({
+      simulatesAskToBuyInSandbox: newSimulatesAskToBuyInSandbox,
+    });
     setSimulatesAskToBuyInSandbox(newSimulatesAskToBuyInSandbox);
-    updateLastFunctionWithoutContent("setSimulatesAskToBuyInSandbox");
+    updateLastFunctionWithoutContent('setSimulatesAskToBuyInSandbox');
   };
 
   const getOfferings = async () => {
     const offerings = await Purchases.getOfferings();
-    updateLastFunction("getOfferings", offerings);
+    updateLastFunction('getOfferings', offerings);
+  };
+
+  const getCurrentOfferingForPlacement = async (
+    placementIdentifier: string,
+  ) => {
+    const offering = await Purchases.getCurrentOfferingForPlacement({
+      placementIdentifier: placementIdentifier,
+    });
+    updateLastFunction('getCurrentOfferingForPlacement', offering);
+  };
+
+  const syncAttributesAndOfferingsIfNeeded = async () => {
+    const offerings = await Purchases.syncAttributesAndOfferingsIfNeeded();
+    updateLastFunction('syncAttributesAndOfferingsIfNeeded', offerings);
   };
 
   const getProducts = async () => {
-    const productIds = ["annual_freetrial", "unknown_product"];
+    const productIds = ['annual_freetrial', 'unknown_product'];
     const products = await Purchases.getProducts({
       productIdentifiers: productIds,
       type: PRODUCT_CATEGORY.SUBSCRIPTION,
     });
-    updateLastFunction("getProducts", products);
+    updateLastFunction('getProducts', products);
   };
 
   const purchaseStoreProduct = async () => {
     const offerings = await Purchases.getOfferings();
-    const productToBuy = offerings.current
-      && offerings.current.availablePackages
-      && offerings.current.availablePackages[0].product;
+    const productToBuy =
+      offerings.current &&
+      offerings.current.availablePackages &&
+      offerings.current.availablePackages[0].product;
     if (productToBuy == null) {
       updateLastFunction(
-        "purchaseStoreProduct",
-        "No product found in current offering",
+        'purchaseStoreProduct',
+        'No product found in current offering',
       );
-      return
+      return;
     }
     const purchaseResult = await Purchases.purchaseStoreProduct({
-      product: productToBuy
+      product: productToBuy,
     });
-    updateLastFunction("purchaseStoreProduct", purchaseResult);
-  }
+    updateLastFunction('purchaseStoreProduct', purchaseResult);
+  };
 
   const purchaseDiscountedProduct = async () => {
     const offerings = await Purchases.getOfferings();
-    const productToBuy = offerings.current
-      && offerings.current.availablePackages
-      && offerings.current.availablePackages[0].product;
+    const productToBuy =
+      offerings.current &&
+      offerings.current.availablePackages &&
+      offerings.current.availablePackages[0].product;
     if (productToBuy == null) {
       updateLastFunction(
-        "purchaseDiscountedProduct",
-        "No product found in current offering",
+        'purchaseDiscountedProduct',
+        'No product found in current offering',
       );
       return;
     }
     const discountToApply = productToBuy.discounts && productToBuy.discounts[0];
     if (discountToApply == null) {
       updateLastFunction(
-        "purchaseDiscountedProduct",
-        "Product did not have any discounts to apply",
+        'purchaseDiscountedProduct',
+        'Product did not have any discounts to apply',
       );
       return;
     }
-    const promotionalOffer = await Purchases.getPromotionalOffer(
-      { product: productToBuy, discount: discountToApply }
-    )
+    const promotionalOffer = await Purchases.getPromotionalOffer({
+      product: productToBuy,
+      discount: discountToApply,
+    });
     if (promotionalOffer == null) {
       updateLastFunction(
-        "purchaseDiscountedProduct",
-        "Could not obtain promotional offer",
+        'purchaseDiscountedProduct',
+        'Could not obtain promotional offer',
       );
       return;
     }
@@ -158,349 +202,521 @@ const FunctionTesterContainer: React.FC<ContainerProps> = () => {
       product: productToBuy,
       discount: promotionalOffer,
     });
-    updateLastFunction("purchaseDiscountedProduct", purchaseResult);
-  }
+    updateLastFunction('purchaseDiscountedProduct', purchaseResult);
+  };
 
   const purchasePackage = async () => {
     const offerings = await Purchases.getOfferings();
-    const packageToBuy = offerings.current
-      && offerings.current.availablePackages
-      && offerings.current.availablePackages[0];
+    const packageToBuy =
+      offerings.current &&
+      offerings.current.availablePackages &&
+      offerings.current.availablePackages[0];
     if (packageToBuy == null) {
       updateLastFunction(
-        "purchasePackage",
-        "No package found in current offering",
+        'purchasePackage',
+        'No package found in current offering',
       );
       return;
     }
     const purchaseResult = await Purchases.purchasePackage({
       aPackage: packageToBuy,
     });
-    updateLastFunction("purchasePackage", purchaseResult);
-  }
+    updateLastFunction('purchasePackage', purchaseResult);
+  };
 
   const purchaseDiscountedPackage = async () => {
     try {
-      const purchaseDiscountedPackageOptions = await getPackageAndOfferForCurrentOfferingFirstPackage();
-      const purchaseResult = await Purchases.purchaseDiscountedPackage(purchaseDiscountedPackageOptions);
-      updateLastFunction("purchaseDiscountedPackage", purchaseResult);
+      const purchaseDiscountedPackageOptions =
+        await getPackageAndOfferForCurrentOfferingFirstPackage();
+      const purchaseResult = await Purchases.purchaseDiscountedPackage(
+        purchaseDiscountedPackageOptions,
+      );
+      updateLastFunction('purchaseDiscountedPackage', purchaseResult);
     } catch (e: any) {
-      updateLastFunction("purchaseDiscountedPackage", e)
+      updateLastFunction('purchaseDiscountedPackage', e);
     }
-  }
+  };
 
   const restorePurchases = async () => {
     const customerInfo = await Purchases.restorePurchases();
-    updateLastFunction("restorePurchases", customerInfo);
+    updateLastFunction('restorePurchases', customerInfo);
   };
 
   const getAppUserID = async () => {
     const appUserID = await Purchases.getAppUserID();
-    updateLastFunction("getAppUserID", appUserID);
+    updateLastFunction('getAppUserID', appUserID);
   };
 
   const logIn = async () => {
-    const appUserIDToUse = "test-capacitor-app-user-id";
-    const customerInfo = await Purchases.logIn({ appUserID: appUserIDToUse});
-    updateLastFunction("logIn", customerInfo);
+    const appUserIDToUse = 'test-capacitor-app-user-id';
+    const customerInfo = await Purchases.logIn({ appUserID: appUserIDToUse });
+    updateLastFunction('logIn', customerInfo);
   };
 
   const logOut = async () => {
     const customerInfo = await Purchases.logOut();
-    updateLastFunction("logOut", customerInfo);
+    updateLastFunction('logOut', customerInfo);
   };
 
   const getCustomerInfo = async () => {
     const customerInfo = await Purchases.getCustomerInfo();
-    updateLastFunction("getCustomerInfo", customerInfo);
+    updateLastFunction('getCustomerInfo', customerInfo);
   };
 
   const syncPurchases = async () => {
     await Purchases.syncPurchases();
-    updateLastFunctionWithoutContent("syncPurchases");
+    updateLastFunctionWithoutContent('syncPurchases');
   };
 
   const syncObserverModeAmazonPurchase = async () => {
-    const productIDToSync = "test-amazon-product-id";
-    const receiptIDToSync = "test-amazon-receipt-id";
-    const amazonUserIDToSync = "test-amazon-user-id";
+    const productIDToSync = 'test-amazon-product-id';
+    const receiptIDToSync = 'test-amazon-receipt-id';
+    const amazonUserIDToSync = 'test-amazon-user-id';
     await Purchases.syncObserverModeAmazonPurchase({
       productID: productIDToSync,
       receiptID: receiptIDToSync,
       amazonUserID: amazonUserIDToSync,
     });
-    updateLastFunctionWithoutContent("syncObserverModeAmazonPurchase");
+    updateLastFunctionWithoutContent('syncObserverModeAmazonPurchase');
   };
 
   const enableAdServicesAttributionTokenCollection = async () => {
     await Purchases.enableAdServicesAttributionTokenCollection();
-    updateLastFunctionWithoutContent("enableAdServicesAttributionTokenCollection");
+    updateLastFunctionWithoutContent(
+      'enableAdServicesAttributionTokenCollection',
+    );
   };
 
   const isAnonymous = async () => {
     const isAnonymousResult = await Purchases.isAnonymous();
-    updateLastFunction("isAnonymous", isAnonymousResult);
+    updateLastFunction('isAnonymous', isAnonymousResult);
   };
 
   const checkTrialOrIntroductoryPriceEligibility = async () => {
-    const productIDsToCheck = ["annual_freetrial"];
-    const checkElibilityResult = await Purchases.checkTrialOrIntroductoryPriceEligibility(
-      { productIdentifiers: productIDsToCheck}
+    const productIDsToCheck = ['annual_freetrial'];
+    const checkElibilityResult =
+      await Purchases.checkTrialOrIntroductoryPriceEligibility({
+        productIdentifiers: productIDsToCheck,
+      });
+    updateLastFunction(
+      'checkTrialOrIntroductoryPriceEligibility',
+      checkElibilityResult,
     );
-    updateLastFunction("checkTrialOrIntroductoryPriceEligibility", checkElibilityResult);
   };
 
   const getPromotionalOffer = async () => {
     try {
-      const purchaseDiscountedPackageOptions = await getPackageAndOfferForCurrentOfferingFirstPackage();
-      updateLastFunction("getPromotionalOffer", purchaseDiscountedPackageOptions.discount);
+      const purchaseDiscountedPackageOptions =
+        await getPackageAndOfferForCurrentOfferingFirstPackage();
+      updateLastFunction(
+        'getPromotionalOffer',
+        purchaseDiscountedPackageOptions.discount,
+      );
     } catch (e: any) {
-      updateLastFunction("purchaseDiscountedPackage", e)
+      updateLastFunction('purchaseDiscountedPackage', e);
     }
   };
 
   const invalidateCustomerInfo = async () => {
     await Purchases.invalidateCustomerInfoCache();
-    updateLastFunctionWithoutContent("invalidateCustomerInfo");
+    updateLastFunctionWithoutContent('invalidateCustomerInfo');
   };
 
   const presentCodeRedemptionSheet = async () => {
     await Purchases.presentCodeRedemptionSheet();
-    updateLastFunctionWithoutContent("presentCodeRedemptionSheet");
+    updateLastFunctionWithoutContent('presentCodeRedemptionSheet');
   };
 
   const setAttributes = async () => {
     const attributesToSet = {
-      "my-test-attribute-1": "test-attribute-value-1",
-      "my-test-attribute-2": "test-attribute-value-2",
-    }
+      'my-test-attribute-1': 'test-attribute-value-1',
+      'my-test-attribute-2': 'test-attribute-value-2',
+    };
     await Purchases.setAttributes(attributesToSet);
-    updateLastFunctionWithoutContent("setAttributes");
+    updateLastFunctionWithoutContent('setAttributes');
   };
 
   const setEmail = async () => {
-    await Purchases.setEmail({ email: "testemail@revenuecat.com" });
-    updateLastFunctionWithoutContent("setEmail");
+    await Purchases.setEmail({ email: 'testemail@revenuecat.com' });
+    updateLastFunctionWithoutContent('setEmail');
   };
 
   const setPhoneNumber = async () => {
-    await Purchases.setPhoneNumber({ phoneNumber: "111-111-1111" });
-    updateLastFunctionWithoutContent("setPhoneNumber");
+    await Purchases.setPhoneNumber({ phoneNumber: '111-111-1111' });
+    updateLastFunctionWithoutContent('setPhoneNumber');
   };
 
   const setDisplayName = async () => {
-    await Purchases.setDisplayName({ displayName: "test-display-name" });
-    updateLastFunctionWithoutContent("setDisplayName");
+    await Purchases.setDisplayName({ displayName: 'test-display-name' });
+    updateLastFunctionWithoutContent('setDisplayName');
   };
 
   const setPushToken = async () => {
-    await Purchases.setPushToken({ pushToken: "test-push-token" });
-    updateLastFunctionWithoutContent("setPushToken");
+    await Purchases.setPushToken({ pushToken: 'test-push-token' });
+    updateLastFunctionWithoutContent('setPushToken');
   };
 
   const setProxyURL = async () => {
-    await Purchases.setProxyURL({ url: "http://localhost:8080:5050/" });
-    updateLastFunctionWithoutContent("setProxyURL");
+    await Purchases.setProxyURL({ url: 'http://localhost:8080:5050/' });
+    updateLastFunctionWithoutContent('setProxyURL');
   };
 
   const collectDeviceIdentifiers = async () => {
     await Purchases.collectDeviceIdentifiers();
-    updateLastFunctionWithoutContent("collectDeviceIdentifiers");
+    updateLastFunctionWithoutContent('collectDeviceIdentifiers');
   };
 
   const setAdjustID = async () => {
-    await Purchases.setAdjustID({ adjustID: "test-adjust-id" });
-    updateLastFunctionWithoutContent("setAdjustID");
+    await Purchases.setAdjustID({ adjustID: 'test-adjust-id' });
+    updateLastFunctionWithoutContent('setAdjustID');
   };
 
   const setAppsflyerID = async () => {
-    await Purchases.setAppsflyerID({ appsflyerID: "test-appsflyer-id" });
-    updateLastFunctionWithoutContent("setAppsflyerID");
+    await Purchases.setAppsflyerID({ appsflyerID: 'test-appsflyer-id' });
+    updateLastFunctionWithoutContent('setAppsflyerID');
   };
 
   const setFBAnonymousID = async () => {
-    await Purchases.setFBAnonymousID({ fbAnonymousID: "test-fb-anonymous-id" });
-    updateLastFunctionWithoutContent("setFBAnonymousID");
+    await Purchases.setFBAnonymousID({ fbAnonymousID: 'test-fb-anonymous-id' });
+    updateLastFunctionWithoutContent('setFBAnonymousID');
   };
 
   const setMparticleID = async () => {
-    await Purchases.setMparticleID({ mparticleID: "test-mparticle-id" });
-    updateLastFunctionWithoutContent("setMparticleID");
+    await Purchases.setMparticleID({ mparticleID: 'test-mparticle-id' });
+    updateLastFunctionWithoutContent('setMparticleID');
   };
 
   const setCleverTapID = async () => {
-    await Purchases.setCleverTapID({ cleverTapID: "test-clever-tap-id" });
-    updateLastFunctionWithoutContent("setCleverTapID");
+    await Purchases.setCleverTapID({ cleverTapID: 'test-clever-tap-id' });
+    updateLastFunctionWithoutContent('setCleverTapID');
   };
 
   const setMixpanelDistinctID = async () => {
-    await Purchases.setMixpanelDistinctID({ mixpanelDistinctID: "test-mixpanel-distinct-id" });
-    updateLastFunctionWithoutContent("setMixpanelDistinctID");
+    await Purchases.setMixpanelDistinctID({
+      mixpanelDistinctID: 'test-mixpanel-distinct-id',
+    });
+    updateLastFunctionWithoutContent('setMixpanelDistinctID');
   };
 
   const setFirebaseAppInstanceID = async () => {
-    await Purchases.setFirebaseAppInstanceID({ firebaseAppInstanceID: "test-firebase-app-instance-id" });
-    updateLastFunctionWithoutContent("setFirebaseAppInstanceID");
+    await Purchases.setFirebaseAppInstanceID({
+      firebaseAppInstanceID: 'test-firebase-app-instance-id',
+    });
+    updateLastFunctionWithoutContent('setFirebaseAppInstanceID');
   };
 
   const setOnesignalID = async () => {
-    await Purchases.setOnesignalID({ onesignalID: "test-onesignal-id" });
-    updateLastFunctionWithoutContent("setOnesignalID");
+    await Purchases.setOnesignalID({ onesignalID: 'test-onesignal-id' });
+    updateLastFunctionWithoutContent('setOnesignalID');
   };
 
   const setAirshipChannelID = async () => {
-    await Purchases.setAirshipChannelID({ airshipChannelID: "test-airship-channel-id" });
-    updateLastFunctionWithoutContent("setAirshipChannelID");
+    await Purchases.setAirshipChannelID({
+      airshipChannelID: 'test-airship-channel-id',
+    });
+    updateLastFunctionWithoutContent('setAirshipChannelID');
   };
 
   const setMediaSource = async () => {
-    await Purchases.setMediaSource({ mediaSource: "test-media-source" });
-    updateLastFunctionWithoutContent("setMediaSource");
+    await Purchases.setMediaSource({ mediaSource: 'test-media-source' });
+    updateLastFunctionWithoutContent('setMediaSource');
   };
 
   const setCampaign = async () => {
-    await Purchases.setCampaign({ campaign: "test-campaign" });
-    updateLastFunctionWithoutContent("setCampaign");
+    await Purchases.setCampaign({ campaign: 'test-campaign' });
+    updateLastFunctionWithoutContent('setCampaign');
   };
 
   const setAdGroup = async () => {
-    await Purchases.setAdGroup({ adGroup: "test-ad-group" });
-    updateLastFunctionWithoutContent("setAdGroup");
+    await Purchases.setAdGroup({ adGroup: 'test-ad-group' });
+    updateLastFunctionWithoutContent('setAdGroup');
   };
 
   const setAd = async () => {
-    await Purchases.setAd({ ad: "test-ad" });
-    updateLastFunctionWithoutContent("setAd");
+    await Purchases.setAd({ ad: 'test-ad' });
+    updateLastFunctionWithoutContent('setAd');
   };
 
   const setKeyword = async () => {
-    await Purchases.setKeyword({ keyword: "test-keyword" });
-    updateLastFunctionWithoutContent("setKeyword");
+    await Purchases.setKeyword({ keyword: 'test-keyword' });
+    updateLastFunctionWithoutContent('setKeyword');
   };
 
   const setCreative = async () => {
-    await Purchases.setCreative({ creative: "test-creative" });
-    updateLastFunctionWithoutContent("setCreative");
+    await Purchases.setCreative({ creative: 'test-creative' });
+    updateLastFunctionWithoutContent('setCreative');
   };
 
   const canMakePayments = async () => {
     const canMakePaymentsResult = await Purchases.canMakePayments();
-    updateLastFunction("canMakePayments", canMakePaymentsResult);
+    updateLastFunction('canMakePayments', canMakePaymentsResult);
   };
 
   const beginRefundRequestForActiveEntitlement = async () => {
-    const refundRequestStatus = await Purchases.beginRefundRequestForActiveEntitlement();
-    updateLastFunction("beginRefundRequestForActiveEntitlement", refundRequestStatus);
+    const refundRequestStatus =
+      await Purchases.beginRefundRequestForActiveEntitlement();
+    updateLastFunction(
+      'beginRefundRequestForActiveEntitlement',
+      refundRequestStatus,
+    );
   };
 
   const beginRefundRequestForEntitlement = async () => {
-    const { customerInfo: {entitlements} } = await Purchases.getCustomerInfo();
-    const activeEntitlements = entitlements.active
-    const activeEntitlementKeys = Object.keys(activeEntitlements)
+    const {
+      customerInfo: { entitlements },
+    } = await Purchases.getCustomerInfo();
+    const activeEntitlements = entitlements.active;
+    const activeEntitlementKeys = Object.keys(activeEntitlements);
     if (activeEntitlementKeys.length == 0) {
-      updateLastFunction("beginRefundRequestForEntitlement", "No active entitlement to refund");
-    } else {
-      const refundRequestStatus = await Purchases.beginRefundRequestForEntitlement(
-        { entitlementInfo: activeEntitlements[activeEntitlementKeys[0]] }
+      updateLastFunction(
+        'beginRefundRequestForEntitlement',
+        'No active entitlement to refund',
       );
-      updateLastFunction("beginRefundRequestForEntitlement", refundRequestStatus);
+    } else {
+      const refundRequestStatus =
+        await Purchases.beginRefundRequestForEntitlement({
+          entitlementInfo: activeEntitlements[activeEntitlementKeys[0]],
+        });
+      updateLastFunction(
+        'beginRefundRequestForEntitlement',
+        refundRequestStatus,
+      );
     }
   };
 
   const beginRefundRequestForProduct = async () => {
-    const { customerInfo: {entitlements} } = await Purchases.getCustomerInfo();
-    const activeEntitlements = entitlements.active
-    const activeEntitlementKeys = Object.keys(activeEntitlements)
+    const {
+      customerInfo: { entitlements },
+    } = await Purchases.getCustomerInfo();
+    const activeEntitlements = entitlements.active;
+    const activeEntitlementKeys = Object.keys(activeEntitlements);
     if (activeEntitlementKeys.length == 0) {
-      updateLastFunction("beginRefundRequestForProduct", "No active entitlement to refund");
-    } else {
-      const activePurchasedProductID = activeEntitlements[activeEntitlementKeys[0]].productIdentifier;
-      const activePurchasedProduct = await Purchases.getProducts(
-        { productIdentifiers: [activePurchasedProductID] }
-      )
-      if (activePurchasedProduct.products.length == 0) {
-        updateLastFunction("beginRefundRequestForProduct", "No product found for active entitlement product id");
-      }
-      const refundRequestStatus = await Purchases.beginRefundRequestForProduct(
-        { storeProduct:  activePurchasedProduct.products[0] }
+      updateLastFunction(
+        'beginRefundRequestForProduct',
+        'No active entitlement to refund',
       );
-      updateLastFunction("beginRefundRequestForProduct", refundRequestStatus);
+    } else {
+      const activePurchasedProductID =
+        activeEntitlements[activeEntitlementKeys[0]].productIdentifier;
+      const activePurchasedProduct = await Purchases.getProducts({
+        productIdentifiers: [activePurchasedProductID],
+      });
+      if (activePurchasedProduct.products.length == 0) {
+        updateLastFunction(
+          'beginRefundRequestForProduct',
+          'No product found for active entitlement product id',
+        );
+      }
+      const refundRequestStatus = await Purchases.beginRefundRequestForProduct({
+        storeProduct: activePurchasedProduct.products[0],
+      });
+      updateLastFunction('beginRefundRequestForProduct', refundRequestStatus);
     }
   };
 
   const showInAppMessages = async () => {
-    await Purchases.showInAppMessages({ messageTypes:
-        [IN_APP_MESSAGE_TYPE.BILLING_ISSUE, IN_APP_MESSAGE_TYPE.PRICE_INCREASE_CONSENT, IN_APP_MESSAGE_TYPE.GENERIC]
+    await Purchases.showInAppMessages({
+      messageTypes: [
+        IN_APP_MESSAGE_TYPE.BILLING_ISSUE,
+        IN_APP_MESSAGE_TYPE.PRICE_INCREASE_CONSENT,
+        IN_APP_MESSAGE_TYPE.GENERIC,
+      ],
     });
-    updateLastFunctionWithoutContent("showInAppMessages");
+    updateLastFunctionWithoutContent('showInAppMessages');
   };
 
   const isConfigured = async () => {
     const isConfiguredResult = await Purchases.isConfigured();
-    updateLastFunction("isConfigured", isConfiguredResult);
+    updateLastFunction('isConfigured', isConfiguredResult);
   };
 
   return (
     <div id="container">
-      <IonCard id={"last_request_card"}>
+      <IonCard id={'last_request_card'}>
         <IonCardHeader>
           <IonCardTitle>Last request result</IonCardTitle>
-          <IonCardSubtitle id={"last_request_subtitle"}>{lastFunctionExecuted}</IonCardSubtitle>
+          <IonCardSubtitle id={'last_request_subtitle'}>
+            {lastFunctionExecuted}
+          </IonCardSubtitle>
         </IonCardHeader>
-        <IonCardContent id={"last_request_content"}><pre>{lastFunctionContent}</pre></IonCardContent>
+        <IonCardContent id={'last_request_content'}>
+          <pre>{lastFunctionContent}</pre>
+        </IonCardContent>
       </IonCard>
 
       <div id="button_actions">
-        <IonButton size="small" onClick={ configure }>Configure</IonButton>
-        <IonButton size="small" onClick={ changeFinishTransactions }>{ `Set finishTransactions to ${!finishTransactions}` }</IonButton>
-        <IonButton size="small" onClick={ changeSimulatesAskToBuyInSandbox }>{ `Set simulatesAskToBuyInSandbox to ${!simulatesAskToBuyInSandbox}` }</IonButton>
-        <IonButton size="small" onClick={ getOfferings }>Get offerings</IonButton>
-        <IonButton size="small" onClick={ getProducts }>Get products</IonButton>
-        <IonButton size="small" onClick={ purchaseStoreProduct }>Purchase current offerings first product</IonButton>
-        <IonButton size="small" onClick={ purchaseDiscountedProduct }>Purchase product with discount</IonButton>
-        <IonButton size="small" onClick={ purchasePackage }>Purchase current offerings first package</IonButton>
-        <IonButton size="small" onClick={ purchaseDiscountedPackage }>Purchase package with discount</IonButton>
-        <IonButton size="small" onClick={ restorePurchases }>Restore purchases</IonButton>
-        <IonButton size="small" onClick={ getAppUserID }>Get current user id</IonButton>
-        <IonButton size="small" onClick={ logIn }>Log in with test-app-user-id</IonButton>
-        <IonButton size="small" onClick={ logOut }>Log out</IonButton>
-        <IonButton size="small" onClick={ getCustomerInfo }>Get customer info</IonButton>
-        <IonButton size="small" onClick={ syncPurchases }>Sync purchases</IonButton>
-        <IonButton size="small" onClick={ syncObserverModeAmazonPurchase }>Sync observer mode amazon purchase</IonButton>
-        <IonButton size="small" onClick={ isAnonymous }>Is anonymous?</IonButton>
-        <IonButton size="small" onClick={ enableAdServicesAttributionTokenCollection }>Enable ad attribution collection</IonButton>
-        <IonButton size="small" onClick={ checkTrialOrIntroductoryPriceEligibility }>Check trial or intro eligibility</IonButton>
-        <IonButton size="small" onClick={ getPromotionalOffer }>Get promotional offer</IonButton>
-        <IonButton size="small" onClick={ invalidateCustomerInfo }>Invalidate customer info</IonButton>
-        <IonButton size="small" onClick={ presentCodeRedemptionSheet }>Present code redemption sheet</IonButton>
-        <IonButton size="small" onClick={ setAttributes }>Set attributes</IonButton>
-        <IonButton size="small" onClick={ setEmail }>Set email</IonButton>
-        <IonButton size="small" onClick={ setPhoneNumber }>Set phoneNumber</IonButton>
-        <IonButton size="small" onClick={ setDisplayName }>Set displayName</IonButton>
-        <IonButton size="small" onClick={ setPushToken }>Set pushToken</IonButton>
-        <IonButton size="small" onClick={ setProxyURL }>Set proxyURL</IonButton>
-        <IonButton size="small" onClick={ collectDeviceIdentifiers }>Collect device identifiers</IonButton>
-        <IonButton size="small" onClick={ setAdjustID }>Set adjustID</IonButton>
-        <IonButton size="small" onClick={ setAppsflyerID }>Set appsflyerID</IonButton>
-        <IonButton size="small" onClick={ setFBAnonymousID }>Set fbAnonymousID</IonButton>
-        <IonButton size="small" onClick={ setMparticleID }>Set mParticleID</IonButton>
-        <IonButton size="small" onClick={ setCleverTapID }>Set cleverTapID</IonButton>
-        <IonButton size="small" onClick={ setMixpanelDistinctID }>Set mixpanelDistinctID</IonButton>
-        <IonButton size="small" onClick={ setFirebaseAppInstanceID }>Set firebaseAppInstanceID</IonButton>
-        <IonButton size="small" onClick={ setOnesignalID }>Set onesignalID</IonButton>
-        <IonButton size="small" onClick={ setAirshipChannelID }>Set airshipChannelID</IonButton>
-        <IonButton size="small" onClick={ setMediaSource }>Set mediaSource</IonButton>
-        <IonButton size="small" onClick={ setCampaign }>Set campaign</IonButton>
-        <IonButton size="small" onClick={ setAdGroup }>Set adGroup</IonButton>
-        <IonButton size="small" onClick={ setAd }>Set ad</IonButton>
-        <IonButton size="small" onClick={ setKeyword }>Set keyword</IonButton>
-        <IonButton size="small" onClick={ setCreative }>Set creative</IonButton>
-        <IonButton size="small" onClick={ canMakePayments }>Can make payments</IonButton>
-        <IonButton size="small" onClick={ beginRefundRequestForActiveEntitlement }>Begin refund for active entitlement</IonButton>
-        <IonButton size="small" onClick={ beginRefundRequestForEntitlement }>Begin refund for entitlement</IonButton>
-        <IonButton size="small" onClick={ beginRefundRequestForProduct }>Begin refund for product</IonButton>
-        <IonButton size="small" onClick={ showInAppMessages }>Show In-app messages</IonButton>
-        <IonButton size="small" onClick={ isConfigured }>Is configured?</IonButton>
+        <IonButton size="small" onClick={configure}>
+          Configure
+        </IonButton>
+        <IonButton
+          size="small"
+          onClick={changeFinishTransactions}
+        >{`Set finishTransactions to ${!finishTransactions}`}</IonButton>
+        <IonButton
+          size="small"
+          onClick={changeSimulatesAskToBuyInSandbox}
+        >{`Set simulatesAskToBuyInSandbox to ${!simulatesAskToBuyInSandbox}`}</IonButton>
+        <IonButton size="small" onClick={getOfferings}>
+          Get offerings
+        </IonButton>
+        <IonButton
+          size="small"
+          onClick={async () => {
+            await getCurrentOfferingForPlacement('placement');
+          }}
+        >
+          Get current offering for placement
+        </IonButton>
+        <IonButton size="small" onClick={syncAttributesAndOfferingsIfNeeded}>
+          Sync attributes and offerings
+        </IonButton>
+        <IonButton size="small" onClick={getProducts}>
+          Get products
+        </IonButton>
+        <IonButton size="small" onClick={purchaseStoreProduct}>
+          Purchase current offerings first product
+        </IonButton>
+        <IonButton size="small" onClick={purchaseDiscountedProduct}>
+          Purchase product with discount
+        </IonButton>
+        <IonButton size="small" onClick={purchasePackage}>
+          Purchase current offerings first package
+        </IonButton>
+        <IonButton size="small" onClick={purchaseDiscountedPackage}>
+          Purchase package with discount
+        </IonButton>
+        <IonButton size="small" onClick={restorePurchases}>
+          Restore purchases
+        </IonButton>
+        <IonButton size="small" onClick={getAppUserID}>
+          Get current user id
+        </IonButton>
+        <IonButton size="small" onClick={logIn}>
+          Log in with test-app-user-id
+        </IonButton>
+        <IonButton size="small" onClick={logOut}>
+          Log out
+        </IonButton>
+        <IonButton size="small" onClick={getCustomerInfo}>
+          Get customer info
+        </IonButton>
+        <IonButton size="small" onClick={syncPurchases}>
+          Sync purchases
+        </IonButton>
+        <IonButton size="small" onClick={syncObserverModeAmazonPurchase}>
+          Sync observer mode amazon purchase
+        </IonButton>
+        <IonButton size="small" onClick={isAnonymous}>
+          Is anonymous?
+        </IonButton>
+        <IonButton
+          size="small"
+          onClick={enableAdServicesAttributionTokenCollection}
+        >
+          Enable ad attribution collection
+        </IonButton>
+        <IonButton
+          size="small"
+          onClick={checkTrialOrIntroductoryPriceEligibility}
+        >
+          Check trial or intro eligibility
+        </IonButton>
+        <IonButton size="small" onClick={getPromotionalOffer}>
+          Get promotional offer
+        </IonButton>
+        <IonButton size="small" onClick={invalidateCustomerInfo}>
+          Invalidate customer info
+        </IonButton>
+        <IonButton size="small" onClick={presentCodeRedemptionSheet}>
+          Present code redemption sheet
+        </IonButton>
+        <IonButton size="small" onClick={setAttributes}>
+          Set attributes
+        </IonButton>
+        <IonButton size="small" onClick={setEmail}>
+          Set email
+        </IonButton>
+        <IonButton size="small" onClick={setPhoneNumber}>
+          Set phoneNumber
+        </IonButton>
+        <IonButton size="small" onClick={setDisplayName}>
+          Set displayName
+        </IonButton>
+        <IonButton size="small" onClick={setPushToken}>
+          Set pushToken
+        </IonButton>
+        <IonButton size="small" onClick={setProxyURL}>
+          Set proxyURL
+        </IonButton>
+        <IonButton size="small" onClick={collectDeviceIdentifiers}>
+          Collect device identifiers
+        </IonButton>
+        <IonButton size="small" onClick={setAdjustID}>
+          Set adjustID
+        </IonButton>
+        <IonButton size="small" onClick={setAppsflyerID}>
+          Set appsflyerID
+        </IonButton>
+        <IonButton size="small" onClick={setFBAnonymousID}>
+          Set fbAnonymousID
+        </IonButton>
+        <IonButton size="small" onClick={setMparticleID}>
+          Set mParticleID
+        </IonButton>
+        <IonButton size="small" onClick={setCleverTapID}>
+          Set cleverTapID
+        </IonButton>
+        <IonButton size="small" onClick={setMixpanelDistinctID}>
+          Set mixpanelDistinctID
+        </IonButton>
+        <IonButton size="small" onClick={setFirebaseAppInstanceID}>
+          Set firebaseAppInstanceID
+        </IonButton>
+        <IonButton size="small" onClick={setOnesignalID}>
+          Set onesignalID
+        </IonButton>
+        <IonButton size="small" onClick={setAirshipChannelID}>
+          Set airshipChannelID
+        </IonButton>
+        <IonButton size="small" onClick={setMediaSource}>
+          Set mediaSource
+        </IonButton>
+        <IonButton size="small" onClick={setCampaign}>
+          Set campaign
+        </IonButton>
+        <IonButton size="small" onClick={setAdGroup}>
+          Set adGroup
+        </IonButton>
+        <IonButton size="small" onClick={setAd}>
+          Set ad
+        </IonButton>
+        <IonButton size="small" onClick={setKeyword}>
+          Set keyword
+        </IonButton>
+        <IonButton size="small" onClick={setCreative}>
+          Set creative
+        </IonButton>
+        <IonButton size="small" onClick={canMakePayments}>
+          Can make payments
+        </IonButton>
+        <IonButton
+          size="small"
+          onClick={beginRefundRequestForActiveEntitlement}
+        >
+          Begin refund for active entitlement
+        </IonButton>
+        <IonButton size="small" onClick={beginRefundRequestForEntitlement}>
+          Begin refund for entitlement
+        </IonButton>
+        <IonButton size="small" onClick={beginRefundRequestForProduct}>
+          Begin refund for product
+        </IonButton>
+        <IonButton size="small" onClick={showInAppMessages}>
+          Show In-app messages
+        </IonButton>
+        <IonButton size="small" onClick={isConfigured}>
+          Is configured?
+        </IonButton>
       </div>
     </div>
   );

--- a/ios/Plugin/PurchasesPlugin.m
+++ b/ios/Plugin/PurchasesPlugin.m
@@ -9,6 +9,8 @@ CAP_PLUGIN(PurchasesPlugin, "Purchases",
            CAP_PLUGIN_METHOD(setFinishTransactions, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(setSimulatesAskToBuyInSandbox, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(getOfferings, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getCurrentOfferingForPlacement, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(syncAttributesAndOfferingsIfNeeded, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getProducts, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(purchaseStoreProduct, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(purchaseDiscountedProduct, CAPPluginReturnPromise);

--- a/ios/Plugin/PurchasesPlugin.swift
+++ b/ios/Plugin/PurchasesPlugin.swift
@@ -92,6 +92,17 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate {
         CommonFunctionality.getOfferings(completion: self.getCompletionBlockHandler(call))
     }
 
+    @objc func getCurrentOfferingForPlacement(_ call: CAPPluginCall) {
+        guard self.rejectIfPurchasesNotConfigured(call) else { return }
+        guard let placementIdentifier = call.getOrRejectString("placementIdentifier") else { return }
+        CommonFunctionality.getCurrentOffering(forPlacement: placementIdentifier, completion: self.getCompletionBlockHandler(call))
+    }
+
+    @objc func syncAttributesAndOfferingsIfNeeded(_ call: CAPPluginCall) {
+        guard self.rejectIfPurchasesNotConfigured(call) else { return }
+        CommonFunctionality.syncAttributesAndOfferingsIfNeeded(completion: self.getCompletionBlockHandler(call))
+    }
+
     @objc func getProducts(_ call: CAPPluginCall) {
         guard self.rejectIfPurchasesNotConfigured(call) else { return }
         guard let productIds = call.getOrRejectStringArray("productIdentifiers") else { return }
@@ -138,12 +149,12 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate {
             call.reject("aPackage parameter did not have identifier key")
             return
         }
-        guard let offeringIdentifier = package["offeringIdentifier"] as? String else {
-            call.reject("aPackage parameter did not have offeringIdentifier key")
+        guard let presentedOfferingContext = package["presentedOfferingContext"] as? [String: Any] else {
+            call.reject("aPackage parameter did not have presentedOfferingContext key")
             return
         }
         CommonFunctionality.purchase(package: packageId,
-                                     offeringIdentifier: offeringIdentifier,
+                                     presentedOfferingContext: presentedOfferingContext,
                                      signedDiscountTimestamp: nil,
                                      completion: self.getCompletionBlockHandler(call))
     }
@@ -159,8 +170,8 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate {
             call.reject("aPackage parameter did not have identifier key")
             return
         }
-        guard let offeringIdentifier = package["offeringIdentifier"] as? String else {
-            call.reject("aPackage parameter did not have offeringIdentifier key")
+        guard let presentedOfferingContext = package["presentedOfferingContext"] as? [String: Any] else {
+            call.reject("aPackage parameter did not have presentedOfferingContext key")
             return
         }
         guard let discount = call.getOrRejectObject("discount") else { return }
@@ -169,7 +180,7 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate {
             return
         }
         CommonFunctionality.purchase(package: packageId,
-                                     offeringIdentifier: offeringIdentifier,
+                                     presentedOfferingContext: presentedOfferingContext,
                                      signedDiscountTimestamp: String(signedDiscountTimestamp),
                                      completion: self.getCompletionBlockHandler(call))
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -230,7 +230,8 @@ export interface PurchasesPlugin {
   getOfferings(): Promise<PurchasesOfferings>;
 
   /**
-   * WORDS
+   * Retrieves a current offering for a placement identifier, use this to access offerings defined by targeting
+   * placements configured in the RevenueCat dashboard.
    * @returns {Promise<PurchasesOffering | null>} WORDS. The promise will be rejected if configure
    * has not been called yet.
    */
@@ -239,7 +240,9 @@ export interface PurchasesPlugin {
   ): Promise<PurchasesOffering | null>;
 
   /**
-   * WORDS
+   * Syncs subscriber attributes and then fetches the configured offerings for this user. This method is intended to
+   * be called when using Targeting Rules with Custom Attributes. Any subscriber attributes should be set before
+   * calling this method to ensure the returned offerings are applied with the latest subscriber attributes.
    * @returns {Promise<PurchasesOfferings>} WORDS. The promise will be rejected if configure
    * has not been called yet.
    */

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -232,7 +232,7 @@ export interface PurchasesPlugin {
   /**
    * Retrieves a current offering for a placement identifier, use this to access offerings defined by targeting
    * placements configured in the RevenueCat dashboard.
-   * @returns {Promise<PurchasesOffering | null>} WORDS. The promise will be rejected if configure
+   * @returns {Promise<PurchasesOffering | null>} Promise of optional offering. The promise will be rejected if configure
    * has not been called yet.
    */
   getCurrentOfferingForPlacement(
@@ -243,7 +243,7 @@ export interface PurchasesPlugin {
    * Syncs subscriber attributes and then fetches the configured offerings for this user. This method is intended to
    * be called when using Targeting Rules with Custom Attributes. Any subscriber attributes should be set before
    * calling this method to ensure the returned offerings are applied with the latest subscriber attributes.
-   * @returns {Promise<PurchasesOfferings>} WORDS. The promise will be rejected if configure
+   * @returns {Promise<PurchasesOfferings>} Promise of entitlements structure. The promise will be rejected if configure
    * has not been called yet.
    */
   syncAttributesAndOfferingsIfNeeded(): Promise<PurchasesOfferings>;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -19,6 +19,7 @@ import type {
   PRODUCT_CATEGORY,
   REFUND_REQUEST_STATUS,
   IN_APP_MESSAGE_TYPE,
+  PurchasesOffering,
 } from '@revenuecat/purchases-typescript-internal-esm';
 
 export * from '@revenuecat/purchases-typescript-internal-esm';
@@ -227,6 +228,22 @@ export interface PurchasesPlugin {
    * has not been called yet.
    */
   getOfferings(): Promise<PurchasesOfferings>;
+
+  /**
+   * WORDS
+   * @returns {Promise<PurchasesOffering | null>} WORDS. The promise will be rejected if configure
+   * has not been called yet.
+   */
+  getCurrentOfferingForPlacement(
+    placementIdentifier: string,
+  ): Promise<PurchasesOffering | null>;
+
+  /**
+   * WORDS
+   * @returns {Promise<PurchasesOfferings>} WORDS. The promise will be rejected if configure
+   * has not been called yet.
+   */
+  syncAttributesAndOfferingsIfNeeded(): Promise<PurchasesOfferings>;
 
   /**
    * Fetch the product info

--- a/src/web.ts
+++ b/src/web.ts
@@ -13,6 +13,7 @@ import type {
   MakePurchaseResult,
   PurchasesConfiguration,
   PurchasesEntitlementInfo,
+  PurchasesOffering,
   PurchasesOfferings,
   PurchasesPromotionalOffer,
   PurchasesStoreProduct,
@@ -99,6 +100,25 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
       current: null,
     };
     return this.mockReturningFunctionIfEnabled('getOfferings', mockOfferings);
+  }
+  getCurrentOfferingForPlacement(
+    _placementIdentifier: string,
+  ): Promise<PurchasesOffering | null> {
+    const mockOffering: PurchasesOffering | null = null;
+    return this.mockReturningFunctionIfEnabled(
+      'getCurrentOfferingForPlacement',
+      mockOffering,
+    );
+  }
+  syncAttributesAndOfferingsIfNeeded(): Promise<PurchasesOfferings> {
+    const mockOfferings: PurchasesOfferings = {
+      all: {},
+      current: null,
+    };
+    return this.mockReturningFunctionIfEnabled(
+      'syncAttributesAndOfferingsIfNeeded',
+      mockOfferings,
+    );
   }
   getProducts(
     _options: GetProductOptions,


### PR DESCRIPTION
## Motivation

Bump to PHC `10.1.0` and add support for new Targeting methods

## Description

### Get Current Offering for Placement

Get an offering specific to the place of your paywall (eg: onboarding, settings, feature gate, etc). This is determined by Targeting.

```ts
let offering = await Purchases.getCurrentOfferingForPlacement("your-placement-identifier")
if (offering) {
    // Navigate to paywall
} else {
    // Do nothing or continue to another screen
}
```

### Sync Attributes and Offerings

A blocking call to sync attributes and fetch new offerings to to be used with Targeting that uses Custom Attributes.

```ts
// Using this result is optional - offerings will be cached for next Purchases.getOfferings() call
let offerings = await Purchases.syncAttributesAndOfferingsIfNeeded()
```