### PR TITLE
Fix `getCurrentOfferingForPlacement` API issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,18 @@ jobs:
       - run: yarn build
       - run: yarn verify:android
 
+  build-purchase-tester:
+    <<: *base-mac-job
+    steps:
+      - checkout
+      - revenuecat/install-gem-mac-dependencies:
+          cache-version: v1
+      - yarn-dependencies-mac
+      - run:
+          name: Build purchase tester
+          command: bundle exec fastlane build_purchase_tester
+
+
   run-lint:
     docker:
       - image: cimg/ruby:3.1.2
@@ -189,6 +201,7 @@ workflows:
       - run-tests-ios
       - run-tests-android
       - run-lint
+      - build-purchase-tester
 
   deploy:
     when:

--- a/README.md
+++ b/README.md
@@ -230,14 +230,15 @@ Gets the map of entitlements -&gt; offerings -&gt; products
 ### getCurrentOfferingForPlacement(...)
 
 ```typescript
-getCurrentOfferingForPlacement(placementIdentifier: string) => Promise<PurchasesOffering | null>
+getCurrentOfferingForPlacement(options: { placementIdentifier: string; }) => Promise<PurchasesOffering | null>
 ```
 
-WORDS
+Retrieves a current offering for a placement identifier, use this to access offerings defined by targeting
+placements configured in the RevenueCat dashboard.
 
-| Param                     | Type                |
-| ------------------------- | ------------------- |
-| **`placementIdentifier`** | <code>string</code> |
+| Param         | Type                                          |
+| ------------- | --------------------------------------------- |
+| **`options`** | <code>{ placementIdentifier: string; }</code> |
 
 **Returns:** <code>Promise&lt;<a href="#purchasesoffering">PurchasesOffering</a> | null&gt;</code>
 
@@ -250,7 +251,9 @@ WORDS
 syncAttributesAndOfferingsIfNeeded() => Promise<PurchasesOfferings>
 ```
 
-WORDS
+Syncs subscriber attributes and then fetches the configured offerings for this user. This method is intended to
+be called when using Targeting Rules with Custom Attributes. Any subscriber attributes should be set before
+calling this method to ensure the returned offerings are applied with the latest subscriber attributes.
 
 **Returns:** <code>Promise&lt;<a href="#purchasesofferings">PurchasesOfferings</a>&gt;</code>
 

--- a/example/purchase-tester/src/components/FunctionTesterContainer.tsx
+++ b/example/purchase-tester/src/components/FunctionTesterContainer.tsx
@@ -130,7 +130,7 @@ const FunctionTesterContainer: React.FC<ContainerProps> = () => {
     const offering = await Purchases.getCurrentOfferingForPlacement({
       placementIdentifier: placementIdentifier,
     });
-    updateLastFunction('getCurrentOfferingForPlacement', offering);
+    updateLastFunction('getCurrentOfferingForPlacement', offering || 'null');
   };
 
   const syncAttributesAndOfferingsIfNeeded = async () => {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -235,9 +235,9 @@ export interface PurchasesPlugin {
    * @returns {Promise<PurchasesOffering | null>} Promise of optional offering. The promise will be rejected if configure
    * has not been called yet.
    */
-  getCurrentOfferingForPlacement(
-    options: { placementIdentifier: string },
-  ): Promise<PurchasesOffering | null>;
+  getCurrentOfferingForPlacement(options: {
+    placementIdentifier: string;
+  }): Promise<PurchasesOffering | null>;
 
   /**
    * Syncs subscriber attributes and then fetches the configured offerings for this user. This method is intended to

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -236,7 +236,7 @@ export interface PurchasesPlugin {
    * has not been called yet.
    */
   getCurrentOfferingForPlacement(
-    placementIdentifier: string,
+    options: { placementIdentifier: string },
   ): Promise<PurchasesOffering | null>;
 
   /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -102,7 +102,7 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
     return this.mockReturningFunctionIfEnabled('getOfferings', mockOfferings);
   }
   getCurrentOfferingForPlacement(
-    _placementIdentifier: string,
+    _options: { placementIdentifier: string },
   ): Promise<PurchasesOffering | null> {
     const mockOffering: PurchasesOffering | null = null;
     return this.mockReturningFunctionIfEnabled(

--- a/src/web.ts
+++ b/src/web.ts
@@ -101,9 +101,9 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
     };
     return this.mockReturningFunctionIfEnabled('getOfferings', mockOfferings);
   }
-  getCurrentOfferingForPlacement(
-    _options: { placementIdentifier: string },
-  ): Promise<PurchasesOffering | null> {
+  getCurrentOfferingForPlacement(_options: {
+    placementIdentifier: string;
+  }): Promise<PurchasesOffering | null> {
     const mockOffering: PurchasesOffering | null = null;
     return this.mockReturningFunctionIfEnabled(
       'getCurrentOfferingForPlacement',


### PR DESCRIPTION
Seems like there was an issue compiling the purchase tester app after the new APIs were added in #222 (These haven't shipped so it's not a breaking change). I fixed the issue and added building purchase tester to the tests
