### PR TITLE
Update CircleCI android machine tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
     executor:
       name: android/android-machine
       resource-class: large
-      tag: 2023.06.1
+      tag: 2024.01.1
     steps:
       - checkout
       - revenuecat/install-gem-unix-dependencies:


### PR DESCRIPTION
We received an email saying the current version was going to experience brownouts. This moves that to the latest tag.
