### PR TITLE
Fix `setAttributes` method to use parameters in the correct location

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
+++ b/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
@@ -371,7 +371,7 @@ class PurchasesPlugin : Plugin() {
     @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun setAttributes(call: PluginCall) {
         if (rejectIfNotConfigured(call)) return
-        val attributes = call.getObject("attributes")?.convertToMap() ?: emptyMap()
+        val attributes = call.data.convertToMap()
         setAttributesCommon(attributes)
         call.resolve()
     }

--- a/ios/Plugin/PropertySetterPluginExtensions.swift
+++ b/ios/Plugin/PropertySetterPluginExtensions.swift
@@ -6,7 +6,11 @@ public extension PurchasesPlugin {
 
     @objc func setAttributes(_ call: CAPPluginCall) {
         guard self.rejectIfPurchasesNotConfigured(call) else { return }
-        guard let attributes = call.getOrRejectObject("attributes") else { return }
+        let attributes = call.jsObjectRepresentation
+        if attributes.isEmpty {
+            call.resolve()
+            return
+        }
         CommonFunctionality.setAttributes(attributes)
         call.resolve()
     }


### PR DESCRIPTION
Currently the native processing assumes all attributes will be under a `attributes` parameter in the method call, but that's actually not allowed in the TS interface.

This PR changes the native processing to pick the attributes from the root of the call data, passing the correct parameters to the native side. This is not completely in line with our other methods in the SDK API where we require a specific parameter key, but this solution allows to avoid a breaking change.
