### PR TITLE
Add support for `setOnesignalUserID` for OneSignal 11+ integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This plugin is based on [CapGo's Capacitor plugin](https://www.npmjs.com/package
 * [`setMixpanelDistinctID(...)`](#setmixpaneldistinctid)
 * [`setFirebaseAppInstanceID(...)`](#setfirebaseappinstanceid)
 * [`setOnesignalID(...)`](#setonesignalid)
+* [`setOnesignalUserID(...)`](#setonesignaluserid)
 * [`setAirshipChannelID(...)`](#setairshipchannelid)
 * [`setMediaSource(...)`](#setmediasource)
 * [`setCampaign(...)`](#setcampaign)
@@ -812,11 +813,27 @@ setOnesignalID(options: { onesignalID: string | null; }) => Promise<void>
 ```
 
 Subscriber attribute associated with the OneSignal Player ID for the user
-Required for the RevenueCat OneSignal integration
+Required for the RevenueCat OneSignal integration. Deprecated for OneSignal versions above v9.0.
 
 | Param         | Type                                          | Description                                                                                                     |
 | ------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | **`options`** | <code>{ onesignalID: string \| null; }</code> | OneSignal Player ID to use in OneSignal integration. Empty String or null will delete the subscriber attribute. |
+
+--------------------
+
+
+### setOnesignalUserID(...)
+
+```typescript
+setOnesignalUserID(options: { onesignalUserID: string | null; }) => Promise<void>
+```
+
+Subscriber attribute associated with the OneSignal User ID for the user
+Required for the RevenueCat OneSignal integration with versions v11.0 and above.
+
+| Param         | Type                                              | Description                                                                                                  |
+| ------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **`options`** | <code>{ onesignalUserID: string \| null; }</code> | OneSignal UserId to use in OneSignal integration. Empty String or null will delete the subscriber attribute. |
 
 --------------------
 

--- a/RevenueCatPurchasesCapacitor.podspec
+++ b/RevenueCatPurchasesCapacitor.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'PurchasesHybridCommon', '10.6.2'
+  s.dependency 'PurchasesHybridCommon', '10.7.0'
   s.swift_version = '5.1'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common:10.6.2'
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common:10.7.0'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
+++ b/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
@@ -61,6 +61,7 @@ import com.revenuecat.purchases.hybridcommon.setMediaSource as setMediaSourceCom
 import com.revenuecat.purchases.hybridcommon.setMixpanelDistinctID as setMixpanelDistinctIDCommon
 import com.revenuecat.purchases.hybridcommon.setMparticleID as setMparticleIDCommon
 import com.revenuecat.purchases.hybridcommon.setOnesignalID as setOnesignalIDCommon
+import com.revenuecat.purchases.hybridcommon.setOnesignalUserID as setOnesignalUserIDCommon
 import com.revenuecat.purchases.hybridcommon.setPhoneNumber as setPhoneNumberCommon
 import com.revenuecat.purchases.hybridcommon.setProxyURLString as setProxyURLStringCommon
 import com.revenuecat.purchases.hybridcommon.setPushToken as setPushTokenCommon
@@ -484,6 +485,14 @@ class PurchasesPlugin : Plugin() {
         if (rejectIfNotConfigured(call)) return
         val onesignalID = call.getString("onesignalID")
         setOnesignalIDCommon(onesignalID)
+        call.resolve()
+    }
+
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
+    fun setOnesignalUserID(call: PluginCall) {
+        if (rejectIfNotConfigured(call)) return
+        val onesignalUserID = call.getString("onesignalUserID")
+        setOnesignalUserIDCommon(onesignalUserID)
         call.resolve()
     }
 

--- a/example/purchase-tester/src/components/FunctionTesterContainer.tsx
+++ b/example/purchase-tester/src/components/FunctionTesterContainer.tsx
@@ -410,6 +410,11 @@ const FunctionTesterContainer: React.FC<ContainerProps> = () => {
     updateLastFunctionWithoutContent('setOnesignalID');
   };
 
+  const setOnesignalUserID = async () => {
+    await Purchases.setOnesignalUserID({ onesignalUserID: 'test-onesignal-user-id' });
+    updateLastFunctionWithoutContent('setOnesignalUserID');
+  };
+
   const setAirshipChannelID = async () => {
     await Purchases.setAirshipChannelID({
       airshipChannelID: 'test-airship-channel-id',
@@ -674,6 +679,9 @@ const FunctionTesterContainer: React.FC<ContainerProps> = () => {
         </IonButton>
         <IonButton size="small" onClick={setOnesignalID}>
           Set onesignalID
+        </IonButton>
+        <IonButton size="small" onClick={setOnesignalUserID}>
+          Set onesignalUserID
         </IonButton>
         <IonButton size="small" onClick={setAirshipChannelID}>
           Set airshipChannelID

--- a/ios/Plugin/PropertySetterPluginExtensions.swift
+++ b/ios/Plugin/PropertySetterPluginExtensions.swift
@@ -99,6 +99,13 @@ public extension PurchasesPlugin {
         call.resolve()
     }
 
+    @objc func setOnesignalUserID(_ call: CAPPluginCall) {
+        guard self.rejectIfPurchasesNotConfigured(call) else { return }
+        let onesignalUserID = call.getString("onesignalUserID")
+        CommonFunctionality.setOnesignalUserID(onesignalUserID)
+        call.resolve()
+    }
+
     @objc func setAirshipChannelID(_ call: CAPPluginCall) {
         guard self.rejectIfPurchasesNotConfigured(call) else { return }
         let airshipChannelID = call.getString("airshipChannelID")

--- a/ios/Plugin/PurchasesPlugin.m
+++ b/ios/Plugin/PurchasesPlugin.m
@@ -46,6 +46,7 @@ CAP_PLUGIN(PurchasesPlugin, "Purchases",
            CAP_PLUGIN_METHOD(setMixpanelDistinctID, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(setFirebaseAppInstanceID, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(setOnesignalID, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(setOnesignalUserID, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(setAirshipChannelID, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(setMediaSource, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(setCampaign, CAPPluginReturnNone);

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,7 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'PurchasesHybridCommon', '10.6.2'
+  pod 'PurchasesHybridCommon', '10.7.0'
 end
 
 target 'Plugin' do

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     }
   },
   "dependencies": {
-    "@revenuecat/purchases-typescript-internal-esm": "10.6.2"
+    "@revenuecat/purchases-typescript-internal-esm": "10.7.0"
   }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -601,13 +601,23 @@ export interface PurchasesPlugin {
 
   /**
    * Subscriber attribute associated with the OneSignal Player ID for the user
-   * Required for the RevenueCat OneSignal integration
+   * Required for the RevenueCat OneSignal integration. Deprecated for OneSignal versions above v9.0.
    *
    * @param options OneSignal Player ID to use in OneSignal integration. Empty String or null will delete the subscriber attribute.
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the OneSignal ID.
    */
   setOnesignalID(options: { onesignalID: string | null }): Promise<void>;
+
+  /**
+   * Subscriber attribute associated with the OneSignal User ID for the user
+   * Required for the RevenueCat OneSignal integration with versions v11.0 and above.
+   *
+   * @param options OneSignal UserId to use in OneSignal integration. Empty String or null will delete the subscriber attribute.
+   * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
+   * setting the OneSignal user ID.
+   */
+  setOnesignalUserID(options: { onesignalUserID: string | null }): Promise<void>;
 
   /**
    * Subscriber attribute associated with the Airship Channel ID for the user

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -617,7 +617,9 @@ export interface PurchasesPlugin {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the OneSignal user ID.
    */
-  setOnesignalUserID(options: { onesignalUserID: string | null }): Promise<void>;
+  setOnesignalUserID(options: {
+    onesignalUserID: string | null;
+  }): Promise<void>;
 
   /**
    * Subscriber attribute associated with the Airship Channel ID for the user

--- a/src/web.ts
+++ b/src/web.ts
@@ -318,7 +318,9 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
   setOnesignalID(_onesignalID: { onesignalID: string | null }): Promise<void> {
     return this.mockNonReturningFunctionIfEnabled('setOnesignalID');
   }
-  setOnesignalUserID(_onesignalUserID: { onesignalUserID: string | null }): Promise<void> {
+  setOnesignalUserID(_onesignalUserID: {
+    onesignalUserID: string | null;
+  }): Promise<void> {
     return this.mockNonReturningFunctionIfEnabled('setOnesignalUserID');
   }
   setAirshipChannelID(_airshipChannelID: {

--- a/src/web.ts
+++ b/src/web.ts
@@ -318,6 +318,9 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
   setOnesignalID(_onesignalID: { onesignalID: string | null }): Promise<void> {
     return this.mockNonReturningFunctionIfEnabled('setOnesignalID');
   }
+  setOnesignalUserID(_onesignalUserID: { onesignalUserID: string | null }): Promise<void> {
+    return this.mockNonReturningFunctionIfEnabled('setOnesignalUserID');
+  }
   setAirshipChannelID(_airshipChannelID: {
     airshipChannelID: string | null;
   }): Promise<void> {


### PR DESCRIPTION
This adds support for the new `setOnesignalUserID` method needed for integration with OneSignal 11+ 
