### PR TITLE
Update definitions.ts to reflect true native expectation of the removeCustomerInfoUpdateListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ Sets a function to be called on updated customer info
 ### removeCustomerInfoUpdateListener(...)
 
 ```typescript
-removeCustomerInfoUpdateListener(listenerToRemove: PurchasesCallbackId) => Promise<{ wasRemoved: boolean; }>
+removeCustomerInfoUpdateListener(options: { listenerToRemove: PurchasesCallbackId; }) => Promise<{ wasRemoved: boolean; }>
 ```
 
 Removes a given <a href="#customerinfoupdatelistener">CustomerInfoUpdateListener</a>
 
-| Param                  | Type                | Description                                                                                              |
-| ---------------------- | ------------------- | -------------------------------------------------------------------------------------------------------- |
-| **`listenerToRemove`** | <code>string</code> | <a href="#customerinfoupdatelistener">CustomerInfoUpdateListener</a> reference of the listener to remove |
+| Param         | Type                                       | Description                                                                                                                                   |
+| ------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`options`** | <code>{ listenerToRemove: string; }</code> | Include listenerToRemove, which is a <a href="#customerinfoupdatelistener">CustomerInfoUpdateListener</a> reference of the listener to remove |
 
 **Returns:** <code>Promise&lt;{ wasRemoved: boolean; }&gt;</code>
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -191,12 +191,13 @@ export interface PurchasesPlugin {
 
   /**
    * Removes a given CustomerInfoUpdateListener
-   * @param {CustomerInfoUpdateListener} listenerToRemove CustomerInfoUpdateListener reference of the listener to remove
+   * @param {CustomerInfoUpdateListener} options Include listenerToRemove, which is a CustomerInfoUpdateListener 
+   * reference of the listener to remove
    * @returns Promise with boolean. True if listener was removed, false otherwise
    */
-  removeCustomerInfoUpdateListener(
+  removeCustomerInfoUpdateListener(options: {
     listenerToRemove: PurchasesCallbackId,
-  ): Promise<{ wasRemoved: boolean }>;
+  }): Promise<{ wasRemoved: boolean }>;
 
   // TODO: Support addShouldPurchasePromoProductListener functionality
   // /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -70,9 +70,9 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
       'mock-callback-id',
     );
   }
-  removeCustomerInfoUpdateListener(
-    _listenerToRemove: string,
-  ): Promise<{ wasRemoved: boolean }> {
+  removeCustomerInfoUpdateListener(_options: {
+    listenerToRemove: string;
+  }): Promise<{ wasRemoved: boolean }> {
     return this.mockReturningFunctionIfEnabled(
       'removeCustomerInfoUpdateListener',
       { wasRemoved: false },


### PR DESCRIPTION
The type definition does not reflect the actual native expectation of the removeCustomerInfoUpdateListener

Thank you for contributing to RevenueCat/purchases-capacitor. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

<strike>  - [ ] If applicable, unit tests.</strike>
