### PR TITLE
Setting `proxyUrl` should not require SDK to be configured

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
+++ b/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
@@ -416,7 +416,6 @@ class PurchasesPlugin : Plugin() {
 
     @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun setProxyURL(call: PluginCall) {
-        if (rejectIfNotConfigured(call)) return
         val urlString = call.getString("url")
         setProxyURLStringCommon(urlString)
         call.resolve()


### PR DESCRIPTION
`setProxyURL` should actually be called before calling `configure` in most scenarios. 