### PR TITLE
[EXTERNAL] Update definitions.ts to reflect true native expectation of the removeCustomerInfoUpdateListener (#280) by @jarvisluong

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,14 +189,14 @@ Sets a function to be called on updated customer info
 ### removeCustomerInfoUpdateListener(...)
 
 ```typescript
-removeCustomerInfoUpdateListener(listenerToRemove: PurchasesCallbackId) => Promise<{ wasRemoved: boolean; }>
+removeCustomerInfoUpdateListener(options: { listenerToRemove: PurchasesCallbackId; }) => Promise<{ wasRemoved: boolean; }>
 ```
 
 Removes a given <a href="#customerinfoupdatelistener">CustomerInfoUpdateListener</a>
 
-| Param                  | Type                | Description                                                                                              |
-| ---------------------- | ------------------- | -------------------------------------------------------------------------------------------------------- |
-| **`listenerToRemove`** | <code>string</code> | <a href="#customerinfoupdatelistener">CustomerInfoUpdateListener</a> reference of the listener to remove |
+| Param         | Type                                       | Description                                                                                                                                   |
+| ------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`options`** | <code>{ listenerToRemove: string; }</code> | Include listenerToRemove, which is a <a href="#customerinfoupdatelistener">CustomerInfoUpdateListener</a> reference of the listener to remove |
 
 **Returns:** <code>Promise&lt;{ wasRemoved: boolean; }&gt;</code>
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -188,12 +188,13 @@ export interface PurchasesPlugin {
 
   /**
    * Removes a given CustomerInfoUpdateListener
-   * @param {CustomerInfoUpdateListener} listenerToRemove CustomerInfoUpdateListener reference of the listener to remove
+   * @param {CustomerInfoUpdateListener} options Include listenerToRemove, which is a CustomerInfoUpdateListener 
+   * reference of the listener to remove
    * @returns Promise with boolean. True if listener was removed, false otherwise
    */
-  removeCustomerInfoUpdateListener(
+  removeCustomerInfoUpdateListener(options: {
     listenerToRemove: PurchasesCallbackId,
-  ): Promise<{ wasRemoved: boolean }>;
+  }): Promise<{ wasRemoved: boolean }>;
 
   // TODO: Support addShouldPurchasePromoProductListener functionality
   // /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -188,12 +188,12 @@ export interface PurchasesPlugin {
 
   /**
    * Removes a given CustomerInfoUpdateListener
-   * @param {CustomerInfoUpdateListener} options Include listenerToRemove, which is a CustomerInfoUpdateListener 
+   * @param {CustomerInfoUpdateListener} options Include listenerToRemove, which is a CustomerInfoUpdateListener
    * reference of the listener to remove
    * @returns Promise with boolean. True if listener was removed, false otherwise
    */
   removeCustomerInfoUpdateListener(options: {
-    listenerToRemove: PurchasesCallbackId,
+    listenerToRemove: PurchasesCallbackId;
   }): Promise<{ wasRemoved: boolean }>;
 
   // TODO: Support addShouldPurchasePromoProductListener functionality

--- a/src/web.ts
+++ b/src/web.ts
@@ -66,9 +66,9 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
       'mock-callback-id',
     );
   }
-  removeCustomerInfoUpdateListener(
-    _listenerToRemove: string,
-  ): Promise<{ wasRemoved: boolean }> {
+  removeCustomerInfoUpdateListener(_options: {
+    listenerToRemove: string;
+  }): Promise<{ wasRemoved: boolean }> {
     return this.mockReturningFunctionIfEnabled(
       'removeCustomerInfoUpdateListener',
       { wasRemoved: false },


### PR DESCRIPTION
The type definition does not reflect the actual native expectation of the removeCustomerInfoUpdateListener

Contributed by @jarvisluong
