### PR TITLE
[EXTERNAL] Make syncPurchases function to actually returning a promise (#305) by @jarvisluong

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
+++ b/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
@@ -310,11 +310,10 @@ class PurchasesPlugin : Plugin() {
         getCustomerInfoCommon(getOnResult(call, CUSTOMER_INFO_KEY))
     }
 
-    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
+    @PluginMethod(returnType = PluginMethod.RETURN_PROMISE)
     fun syncPurchases(call: PluginCall) {
         if (rejectIfNotConfigured(call)) return
-        syncPurchasesCommon()
-        call.resolve()
+        syncPurchasesCommon(getOnResult(call))
     }
 
     @PluginMethod(returnType = PluginMethod.RETURN_NONE)

--- a/ios/Plugin/PurchasesPlugin.m
+++ b/ios/Plugin/PurchasesPlugin.m
@@ -24,7 +24,7 @@ CAP_PLUGIN(PurchasesPlugin, "Purchases",
            CAP_PLUGIN_METHOD(logOut, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setLogLevel, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(getCustomerInfo, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(syncPurchases, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(syncPurchases, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(syncObserverModeAmazonPurchase, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(enableAdServicesAttributionTokenCollection, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(isAnonymous, CAPPluginReturnPromise);


### PR DESCRIPTION
This small change will make capacitor to actually resolving or rejecting the promise of syncPurchases. Without this change, syncPurchases function will always return -1 no matter if it is successful or not.

Contributed by @jarvisluong

