### PR TITLE
Sets the `launchMode` of the Android sample app to `singleTop`.

### DIFF
--- a/example/purchase-tester/android/app/src/main/AndroidManifest.xml
+++ b/example/purchase-tester/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
             android:name="com.revenuecat.purchase_tester.MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
-            android:launchMode="singleTask"
+            android:launchMode="singleTop"
             android:exported="true">
 
             <intent-filter>


### PR DESCRIPTION
## Motivation
The default `launchMode` set by Capacitor (`singleTask`) causes issues in the purchase flow if users need to verify the payment in a separate (banking) app. The Google Play overlay is gone when they return to the app, causing the purchase to get canceled. We found and fixed this in a recent [Zendesk ticket](https://revenuecat.zendesk.com/agent/tickets/45929).

I figured it's a good idea for our own sample to give the right _example_. I picked `singleTop`, because that seems closest in behavior to `singleTask`, while still fixing the issue. Let me know what you think! 