### PR TITLE
Downgrade Java version to 1.8 and set kotlin JVM target 1.8 to fix compilation issues in newer android studios

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,11 +39,11 @@ android {
         abortOnError false
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-       jvmTarget = "17"
+       jvmTarget = '1.8'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    kotlinOptions {
+       jvmTarget = "17"
+    }
 }
 
 repositories {


### PR DESCRIPTION
Compiling the android app in newer android studios was failing because it was trying to use jvm 21, which isn't compatible. Additionally as @JayShortway, we were using a higher version of Java that we should. We were mostly ok, but this brings the levelt to the same as our native android SDK and other hybrids.