### PR TITLE
Remove routing from sample app to fix compile issue

### DIFF
--- a/example/purchase-tester/src/App.tsx
+++ b/example/purchase-tester/src/App.tsx
@@ -1,6 +1,4 @@
-import { Redirect, Route } from 'react-router-dom';
 import { IonApp, setupIonicReact } from '@ionic/react';
-import { IonReactRouter } from '@ionic/react-router';
 import Home from './pages/Home';
 
 /* Core CSS required for Ionic components to work properly */
@@ -26,14 +24,7 @@ setupIonicReact();
 
 const App: React.FC = () => (
   <IonApp>
-    <IonReactRouter>
-      <Route exact path="/home">
-        <Home />
-      </Route>
-      <Route exact path="/">
-        <Redirect to="/home" />
-      </Route>
-    </IonReactRouter>
+    <Home />
   </IonApp>
 );
 


### PR DESCRIPTION
~11 days ago, building our sample app started failing with an error like [this](https://app.circleci.com/pipelines/github/RevenueCat/purchases-capacitor/706/workflows/df589a14-49ac-466d-8135-a4db44c601d3/jobs/3667). 
```
yarn install v1.22.22
info No lockfile found.
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/4] 🔍  Resolving packages...
warning eslint@8.57.1: This version is no longer supported. Please see https://eslint.org/version-support for other options.
warning eslint > @humanwhocodes/config-array@0.13.0: Use @eslint/config-array instead
warning eslint > file-entry-cache > flat-cache > rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
warning eslint > file-entry-cache > flat-cache > rimraf > glob@7.2.3: Glob versions prior to v9 are no longer supported
warning eslint > @humanwhocodes/config-array > @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
warning eslint > file-entry-cache > flat-cache > rimraf > glob > inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
warning jsdom > abab@2.0.6: Use your platform's native atob() and btoa() methods instead
warning jsdom > data-urls > abab@2.0.6: Use your platform's native atob() and btoa() methods instead
warning jsdom > domexception@4.0.0: Use your platform's native DOMException instead
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
✨  Done in 33.21s.
yarn run v1.22.22
$ tsc && vite build
src/App.tsx:42:10 - error TS2786: 'Route' cannot be used as a JSX component.
  Its type 'typeof Route' is not a valid JSX element type.
    Types of construct signatures are incompatible.
      Type 'new <T extends {} = {}, Path extends string = string>(props: RouteProps<Path, ExtractRouteParams<Path, string>> & OmitNative<T, keyof RouteProps<string, { [x: string]: string | undefined; }>>) => Route<...>' is not assignable to type 'new (props: any, deprecatedLegacyContext?: any) => Component<any, any, any>'.
        Property 'refs' is missing in type 'Route<{}, string>' but required in type 'Component<any, any, any>'.

42         <Route exact path="/home">
            ~~~~~

  node_modules/@types/react/index.d.ts:1033:9
    1033         refs: {
                 ~~~~
    'refs' is declared here.

src/App.tsx:45:10 - error TS2786: 'Route' cannot be used as a JSX component.
  Its type 'typeof Route' is not a valid JSX element type.
    Types of construct signatures are incompatible.
      Type 'new <T extends {} = {}, Path extends string = string>(props: RouteProps<Path, ExtractRouteParams<Path, string>> & OmitNative<T, keyof RouteProps<string, { [x: string]: string | undefined; }>>) => Route<...>' is not assignable to type 'new (props: any, deprecatedLegacyContext?: any) => Component<any, any, any>'.
        Property 'refs' is missing in type 'Route<{}, string>' but required in type 'Component<any, any, any>'.

45         <Route exact path="/">
            ~~~~~

  node_modules/@types/react/index.d.ts:1033:9
    1033         refs: {
                 ~~~~
    'refs' is declared here.

src/App.tsx:46:12 - error TS2786: 'Redirect' cannot be used as a JSX component.
  Its type 'typeof Redirect' is not a valid JSX element type.
    Types of construct signatures are incompatible.
      Type 'new (props: RedirectProps) => Redirect' is not assignable to type 'new (props: any, deprecatedLegacyContext?: any) => Component<any, any, any>'.
        Property 'refs' is missing in type 'Component<RedirectProps, any, any>' but required in type 'Component<any, any, any>'.

46           <Redirect to="/home" />
              ~~~~~~~~

  node_modules/@types/react/index.d.ts:1033:9
    1033         refs: {
                 ~~~~
    'refs' is declared here.


Found 3 errors in the same file, starting at: src/App.tsx:42

error Command failed with exit code 2.
```

I believe this is a dependency issue. I was actually able to reproduce with a new empty sample app from the [ionic wizard](https://ionicframework.com/docs/intro/cli#start-an-app).

I didn't want to spend too much longer debugging the issue, so I decided to simply remove the routing from our sample app for now since we don't really need it (we only have one screen).