### PR TITLE
Run PurchaseTester app with purchasesAreCompletedBy=REVENEUCAT by default

### DIFF
--- a/example/purchase-tester/src/components/FunctionTesterContainer.tsx
+++ b/example/purchase-tester/src/components/FunctionTesterContainer.tsx
@@ -82,10 +82,6 @@ const FunctionTesterContainer: React.FC<ContainerProps> = () => {
   const configure = async () => {
     await Purchases.configure({
       apiKey: REVENUECAT_API_KEY,
-      purchasesAreCompletedBy: {
-        type: PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT,
-        storeKitVersion: STOREKIT_VERSION.STOREKIT_2,
-      },
       entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL,
       pendingTransactionsForPrepaidPlansEnabled: true,
       diagnosticsEnabled: true,

--- a/example/purchase-tester/src/components/FunctionTesterContainer.tsx
+++ b/example/purchase-tester/src/components/FunctionTesterContainer.tsx
@@ -83,7 +83,7 @@ const FunctionTesterContainer: React.FC<ContainerProps> = () => {
     await Purchases.configure({
       apiKey: REVENUECAT_API_KEY,
       purchasesAreCompletedBy: {
-        type: PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP,
+        type: PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT,
         storeKitVersion: STOREKIT_VERSION.STOREKIT_2,
       },
       entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL,


### PR DESCRIPTION
This PR modifies the purchase tester app to not use purchasesAreCompletedBy=MY_APP by default