### PR TITLE
Fix repo source url for CocoaPods

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/RevenueCat/purchases-capacitor.git"
+    "url": "https://github.com/RevenueCat/purchases-capacitor.git"
   },
   "bugs": {
     "url": "https://github.com/RevenueCat/purchases-capacitor/issues"


### PR DESCRIPTION
This PR fixes the repository URL in `package.json` so that uploading the CocoaPods specification works correctly with `pod trunk push`.