### PR TITLE
Update fastlane plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 3b1e7cfc41048ead742195d56ec1c3c0070357ea
+  revision: 05ef0952ecb3b92398a0185a3f74019abd0c1d95
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri
@@ -203,7 +203,7 @@ GEM
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
     ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -261,13 +261,14 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    logger (1.6.1)
+    logger (1.6.6)
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.1203)
+    mime-types-data (3.2025.0304)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.8)
     minitest (5.25.1)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -277,9 +278,8 @@ GEM
     naturally (2.2.1)
     netrc (0.11.0)
     nkf (0.2.0)
-    nokogiri (1.16.8-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.8-x86_64-linux)
+    nokogiri (1.18.3)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (9.2.0)
       faraday (>= 1, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
     ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-linux)
+    ffi (1.17.0-x86_64-linux-gnu)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)


### PR DESCRIPTION
This updates the fastlane plugin to the latest version. I'm not sure why dependabot is not picking these automatically, and I didn't find anything after a cursory glance, so decided to just update it manually for now.
