### PR TITLE
Add iOS PresentPaywall for Capacitor

### DIFF
--- a/PurchasesCapacitor.podspec
+++ b/PurchasesCapacitor.podspec
@@ -1,0 +1,18 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name = 'PurchasesCapacitor'
+  s.version = package['version']
+  s.summary = package['description']
+  s.license = package['license']
+  s.homepage = package['repository']['url']
+  s.author = package['author']
+  s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
+  s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
+  s.ios.deployment_target = '15.0'
+  s.dependency 'Capacitor'
+  s.dependency 'PurchasesHybridCommon', '13.32.0'
+  s.swift_version = '5.1'
+end

--- a/purchases-capacitor-ui/PurchasesCapacitorUi.podspec
+++ b/purchases-capacitor-ui/PurchasesCapacitorUi.podspec
@@ -1,0 +1,18 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name = 'PurchasesCapacitorUi'
+  s.version = package['version']
+  s.summary = package['description']
+  s.license = package['license']
+  s.homepage = package['repository']['url']
+  s.author = package['author']
+  s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
+  s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
+  s.ios.deployment_target = '15.0'
+  s.dependency 'Capacitor'
+  s.dependency 'PurchasesHybridCommonUI', '13.32.0'
+  s.swift_version = '5.1'
+end 

--- a/purchases-capacitor-ui/README.md
+++ b/purchases-capacitor-ui/README.md
@@ -1,0 +1,99 @@
+# @revenuecat/purchases-capacitor-ui
+
+UI components for RevenueCat Capacitor SDK. This plugin extends the functionality of the [@revenuecat/purchases-capacitor](https://github.com/RevenueCat/purchases-capacitor) plugin to provide UI components for displaying paywalls and customer center.
+
+## Install
+
+```bash
+npm install @revenuecat/purchases-capacitor
+npm install @revenuecat/purchases-capacitor-ui
+npx cap sync
+```
+
+> Note: Make sure to use the same version for both `@revenuecat/purchases-capacitor` and `@revenuecat/purchases-capacitor-ui`.
+
+## API
+
+<docgen-index>
+
+* [`presentPaywall(...)`](#presentpaywall)
+* [`presentPaywallIfNeeded(...)`](#presentpaywallIfNeeded)
+* [`presentCustomerCenter()`](#presentcustomercenter)
+* [`addListener('paywallDisplayed', ...)`](#addlistenerpaywallDisplayed)
+* [`addListener('paywallDismissed', ...)`](#addlistenerpaywallDismissed)
+* [`removeAllListeners()`](#removealllisteners)
+* [Interfaces](#interfaces)
+* [Enums](#enums)
+
+</docgen-index>
+
+<docgen-api>
+<!--Update with API docs-->
+</docgen-api>
+
+## Usage
+
+### Initialization
+
+First, initialize the main RevenueCat SDK:
+
+```typescript
+import { Purchases } from '@revenuecat/purchases-capacitor';
+
+// Initialize the SDK
+await Purchases.configure({
+  apiKey: 'your_api_key',
+});
+```
+
+### Presenting Paywalls
+
+```typescript
+import { RevenueCatUI } from '@revenuecat/purchases-capacitor-ui';
+
+// Present a paywall with the default offering
+const result = await RevenueCatUI.presentPaywall();
+
+// Present a paywall with a specific offering
+const result = await RevenueCatUI.presentPaywall({
+  offeringIdentifier: 'premium',
+  displayCloseButton: true
+});
+
+// Present a paywall only if the user doesn't have a specific entitlement
+const result = await RevenueCatUI.presentPaywallIfNeeded({
+  requiredEntitlementIdentifier: 'pro_access',
+  offeringIdentifier: 'premium'
+});
+```
+
+### Customer Center
+
+```typescript
+import { RevenueCatUI } from '@revenuecat/purchases-capacitor-ui';
+
+// Present the customer center
+await RevenueCatUI.presentCustomerCenter();
+```
+
+## Events
+
+You can listen for paywall events:
+
+```typescript
+import { RevenueCatUI } from '@revenuecat/purchases-capacitor-ui';
+
+// Listen for when a paywall is displayed
+RevenueCatUI.addListener('paywallDisplayed', () => {
+  console.log('Paywall displayed');
+});
+
+// Listen for when a paywall is dismissed
+RevenueCatUI.addListener('paywallDismissed', () => {
+  console.log('Paywall dismissed');
+});
+```
+
+## License
+
+MIT 

--- a/purchases-capacitor-ui/README.md
+++ b/purchases-capacitor-ui/README.md
@@ -2,6 +2,14 @@
 
 UI components for RevenueCat Capacitor SDK. This plugin extends the functionality of the [@revenuecat/purchases-capacitor](https://github.com/RevenueCat/purchases-capacitor) plugin to provide UI components for displaying paywalls and customer center.
 
+## Platform Support
+
+> ⚠️ **IMPORTANT: Platform Limitations**
+>
+> - **iOS**: Paywalls and Customer Center are fully supported on iOS 15.0+
+> - **Android**: Paywalls and Customer Center are **NOT YET SUPPORTED** on Android. API calls will resolve gracefully without errors but will not display any UI.
+> - **Web**: Not supported
+
 ## Install
 
 ```bash
@@ -11,6 +19,10 @@ npx cap sync
 ```
 
 > Note: Make sure to use the same version for both `@revenuecat/purchases-capacitor` and `@revenuecat/purchases-capacitor-ui`.
+
+## iOS Configuration
+
+For iOS, you need to add SwiftUI to your app's capabilities. Follow the [iOS SDK's SwiftUI Configuration](https://github.com/RevenueCat/purchases-ios-ui#swift-package-manager) guide for details.
 
 ## API
 
@@ -48,6 +60,8 @@ await Purchases.configure({
 
 ### Presenting Paywalls
 
+> ⚠️ **Note**: Paywalls are currently only supported on iOS 15.0+. On Android, these methods will resolve gracefully but will not display any UI.
+
 ```typescript
 import { RevenueCatUI } from '@revenuecat/purchases-capacitor-ui';
 
@@ -69,12 +83,22 @@ const result = await RevenueCatUI.presentPaywallIfNeeded({
 
 ### Customer Center
 
+> ⚠️ **Note**: Customer Center is currently only supported on iOS 15.0+. On Android, this method will resolve gracefully but will not display any UI.
+
 ```typescript
 import { RevenueCatUI } from '@revenuecat/purchases-capacitor-ui';
 
 // Present the customer center
 await RevenueCatUI.presentCustomerCenter();
 ```
+
+## Demo
+
+Here's a quick demo of Paywalls running on iOS:
+
+![iOS Paywalls Demo](./assets/ios-paywalls-demo.mp4)
+
+> Note: To view the demo, please download the MP4 file from the assets directory.
 
 ## Events
 

--- a/purchases-capacitor-ui/RevenuecatPurchasesCapacitorUI.podspec
+++ b/purchases-capacitor-ui/RevenuecatPurchasesCapacitorUI.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name = 'RevenuecatPurchasesCapacitorUI'
+  s.version = package['version']
+  s.summary = package['description']
+  s.license = package['license']
+  s.homepage = package['repository']['url']
+  s.author = package['author']
+  s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
+  s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
+  s.ios.deployment_target = '13.0'
+  s.dependency 'Capacitor'
+  s.dependency 'RevenueCat', '~> 4.31.5'
+  s.dependency 'RevenueCatUI', '~> 4.31.5'
+  s.swift_version = '5.1'
+end 

--- a/purchases-capacitor-ui/android/build.gradle
+++ b/purchases-capacitor-ui/android/build.gradle
@@ -1,0 +1,58 @@
+ext {
+    junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
+    androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.4.2'
+    androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
+    androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'
+}
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.2.1'
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    namespace "com.revenuecat.purchases.capacitor.ui"
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
+    defaultConfig {
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 33
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    lintOptions {
+        abortOnError false
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':capacitor-android')
+    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    implementation 'com.revenuecat.purchases:purchases:7.4.0'
+    implementation 'com.revenuecat.purchases:purchases-ui:7.4.0'
+    testImplementation "junit:junit:$junitVersion"
+    androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
+} 

--- a/purchases-capacitor-ui/android/src/main/java/com/revenuecat/purchases/capacitor/ui/RevenueCatUIPlugin.java
+++ b/purchases-capacitor-ui/android/src/main/java/com/revenuecat/purchases/capacitor/ui/RevenueCatUIPlugin.java
@@ -5,7 +5,6 @@ import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
-
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -21,88 +20,93 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallResult;
 
 @CapacitorPlugin(name = "RevenueCatUI")
 public class RevenueCatUIPlugin extends Plugin {
-    
+
     private PluginCall savedCall;
     private ActivityResultLauncher<Intent> paywallLauncher;
     private ActivityResultLauncher<Intent> customerCenterLauncher;
-    
+
     @Override
     public void load() {
         super.load();
-        
-        paywallLauncher = getActivity().registerForActivityResult(
-            new ActivityResultContracts.StartActivityForResult(),
-            new ActivityResultCallback<ActivityResult>() {
-                @Override
-                public void onActivityResult(ActivityResult result) {
-                    handlePaywallResult(result);
-                }
-            }
-        );
-        
-        customerCenterLauncher = getActivity().registerForActivityResult(
-            new ActivityResultContracts.StartActivityForResult(),
-            new ActivityResultCallback<ActivityResult>() {
-                @Override
-                public void onActivityResult(ActivityResult result) {
-                    if (savedCall != null) {
-                        savedCall.resolve();
-                        savedCall = null;
+
+        paywallLauncher = getActivity()
+            .registerForActivityResult(
+                new ActivityResultContracts.StartActivityForResult(),
+                new ActivityResultCallback<ActivityResult>() {
+                    @Override
+                    public void onActivityResult(ActivityResult result) {
+                        handlePaywallResult(result);
                     }
                 }
-            }
-        );
+            );
+
+        customerCenterLauncher = getActivity()
+            .registerForActivityResult(
+                new ActivityResultContracts.StartActivityForResult(),
+                new ActivityResultCallback<ActivityResult>() {
+                    @Override
+                    public void onActivityResult(ActivityResult result) {
+                        if (savedCall != null) {
+                            savedCall.resolve();
+                            savedCall = null;
+                        }
+                    }
+                }
+            );
     }
-    
+
     @PluginMethod
     public void presentPaywall(final PluginCall call) {
         // Gracefully handle unsupported feature on Android
         JSObject result = new JSObject();
         result.put("result", "NOT_PRESENTED");
         call.resolve(result);
-        
+
         // Log warning that this feature is not available on Android yet
-        getActivity().runOnUiThread(() -> {
-            Purchases.getSharedInstance().logMessage("RevenueCatUI warning: Paywalls are not supported on Android yet.");
-        });
+        getActivity()
+            .runOnUiThread(() -> {
+                Purchases.getSharedInstance().logMessage("RevenueCatUI warning: Paywalls are not supported on Android yet.");
+            });
     }
-    
+
     @PluginMethod
     public void presentPaywallIfNeeded(final PluginCall call) {
         // Gracefully handle unsupported feature on Android
         JSObject result = new JSObject();
         result.put("result", "NOT_PRESENTED");
         call.resolve(result);
-        
+
         // Log warning that this feature is not available on Android yet
-        getActivity().runOnUiThread(() -> {
-            Purchases.getSharedInstance().logMessage("RevenueCatUI warning: Paywalls are not supported on Android yet.");
-        });
+        getActivity()
+            .runOnUiThread(() -> {
+                Purchases.getSharedInstance().logMessage("RevenueCatUI warning: Paywalls are not supported on Android yet.");
+            });
     }
-    
+
     @PluginMethod
     public void presentCustomerCenter(PluginCall call) {
         // Gracefully handle unsupported feature on Android
         call.resolve();
-        
+
         // Log warning that this feature is not available on Android yet
-        getActivity().runOnUiThread(() -> {
-            Purchases.getSharedInstance().logMessage("RevenueCatUI warning: Customer Center is not supported on Android yet.");
-        });
+        getActivity()
+            .runOnUiThread(() -> {
+                Purchases.getSharedInstance().logMessage("RevenueCatUI warning: Customer Center is not supported on Android yet.");
+            });
     }
-    
+
     private void launchPaywall(com.revenuecat.purchases.Offering offering, PluginCall call) {
         savedCall = call;
         Intent intent = PaywallActivity.newIntent(getActivity(), offering);
         notifyListeners("paywallDisplayed", new JSObject());
         paywallLauncher.launch(intent);
     }
-    
+
     private void handlePaywallResult(ActivityResult result) {
         if (savedCall == null) {
             return;
         }
-        
+
         if (result.getResultCode() == PaywallResult.PURCHASED.getResultCode()) {
             JSObject jsObject = new JSObject();
             jsObject.put("result", "PURCHASED");
@@ -120,8 +124,8 @@ public class RevenueCatUIPlugin extends Plugin {
             jsObject.put("result", "ERROR");
             savedCall.resolve(jsObject);
         }
-        
+
         notifyListeners("paywallDismissed", new JSObject());
         savedCall = null;
     }
-} 
+}

--- a/purchases-capacitor-ui/android/src/main/java/com/revenuecat/purchases/capacitor/ui/RevenueCatUIPlugin.java
+++ b/purchases-capacitor-ui/android/src/main/java/com/revenuecat/purchases/capacitor/ui/RevenueCatUIPlugin.java
@@ -1,0 +1,202 @@
+package com.revenuecat.purchases.capacitor.ui;
+
+import android.content.Intent;
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import com.revenuecat.purchases.CustomerInfo;
+import com.revenuecat.purchases.Offerings;
+import com.revenuecat.purchases.Purchases;
+import com.revenuecat.purchases.ui.CustomerCenterActivity;
+import com.revenuecat.purchases.ui.revenuecatui.PaywallActivity;
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions;
+import com.revenuecat.purchases.ui.revenuecatui.PaywallResult;
+
+@CapacitorPlugin(name = "RevenueCatUI")
+public class RevenueCatUIPlugin extends Plugin {
+    
+    private PluginCall savedCall;
+    private ActivityResultLauncher<Intent> paywallLauncher;
+    private ActivityResultLauncher<Intent> customerCenterLauncher;
+    
+    @Override
+    public void load() {
+        super.load();
+        
+        paywallLauncher = getActivity().registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            new ActivityResultCallback<ActivityResult>() {
+                @Override
+                public void onActivityResult(ActivityResult result) {
+                    handlePaywallResult(result);
+                }
+            }
+        );
+        
+        customerCenterLauncher = getActivity().registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            new ActivityResultCallback<ActivityResult>() {
+                @Override
+                public void onActivityResult(ActivityResult result) {
+                    if (savedCall != null) {
+                        savedCall.resolve();
+                        savedCall = null;
+                    }
+                }
+            }
+        );
+    }
+    
+    @PluginMethod
+    public void presentPaywall(final PluginCall call) {
+        String offeringIdentifier = call.getString("offeringIdentifier");
+        
+        if (offeringIdentifier != null) {
+            Purchases.getSharedInstance().getOfferings(new Purchases.GetOfferingsListener() {
+                @Override
+                public void onReceived(Offerings offerings) {
+                    if (offerings.getOffering(offeringIdentifier) != null) {
+                        launchPaywall(offerings.getOffering(offeringIdentifier), call);
+                    } else {
+                        call.reject("Offering not found: " + offeringIdentifier);
+                    }
+                }
+                
+                @Override
+                public void onError(Exception error) {
+                    call.reject("Failed to get offerings: " + error.getMessage());
+                }
+            });
+        } else {
+            Purchases.getSharedInstance().getOfferings(new Purchases.GetOfferingsListener() {
+                @Override
+                public void onReceived(Offerings offerings) {
+                    if (offerings.getCurrentOffering() != null) {
+                        launchPaywall(offerings.getCurrentOffering(), call);
+                    } else {
+                        call.reject("No current offering found");
+                    }
+                }
+                
+                @Override
+                public void onError(Exception error) {
+                    call.reject("Failed to get offerings: " + error.getMessage());
+                }
+            });
+        }
+    }
+    
+    @PluginMethod
+    public void presentPaywallIfNeeded(final PluginCall call) {
+        String requiredEntitlementIdentifier = call.getString("requiredEntitlementIdentifier");
+        if (requiredEntitlementIdentifier == null) {
+            call.reject("Required entitlement identifier is missing");
+            return;
+        }
+        
+        Purchases.getSharedInstance().getCustomerInfo(new Purchases.GetCustomerInfoListener() {
+            @Override
+            public void onReceived(CustomerInfo customerInfo) {
+                if (customerInfo.getEntitlements().get(requiredEntitlementIdentifier) != null && 
+                    customerInfo.getEntitlements().get(requiredEntitlementIdentifier).isActive()) {
+                    JSObject result = new JSObject();
+                    result.put("result", "NOT_PRESENTED");
+                    call.resolve(result);
+                    return;
+                }
+                
+                String offeringIdentifier = call.getString("offeringIdentifier");
+                
+                if (offeringIdentifier != null) {
+                    Purchases.getSharedInstance().getOfferings(new Purchases.GetOfferingsListener() {
+                        @Override
+                        public void onReceived(Offerings offerings) {
+                            if (offerings.getOffering(offeringIdentifier) != null) {
+                                launchPaywall(offerings.getOffering(offeringIdentifier), call);
+                            } else if (offerings.getCurrentOffering() != null) {
+                                launchPaywall(offerings.getCurrentOffering(), call);
+                            } else {
+                                call.reject("No offering found");
+                            }
+                        }
+                        
+                        @Override
+                        public void onError(Exception error) {
+                            call.reject("Failed to get offerings: " + error.getMessage());
+                        }
+                    });
+                } else {
+                    Purchases.getSharedInstance().getOfferings(new Purchases.GetOfferingsListener() {
+                        @Override
+                        public void onReceived(Offerings offerings) {
+                            if (offerings.getCurrentOffering() != null) {
+                                launchPaywall(offerings.getCurrentOffering(), call);
+                            } else {
+                                call.reject("No current offering found");
+                            }
+                        }
+                        
+                        @Override
+                        public void onError(Exception error) {
+                            call.reject("Failed to get offerings: " + error.getMessage());
+                        }
+                    });
+                }
+            }
+            
+            @Override
+            public void onError(Exception error) {
+                call.reject("Failed to get customer info: " + error.getMessage());
+            }
+        });
+    }
+    
+    @PluginMethod
+    public void presentCustomerCenter(PluginCall call) {
+        savedCall = call;
+        Intent intent = CustomerCenterActivity.newIntent(getActivity());
+        notifyListeners("paywallDisplayed", new JSObject());
+        customerCenterLauncher.launch(intent);
+    }
+    
+    private void launchPaywall(com.revenuecat.purchases.Offering offering, PluginCall call) {
+        savedCall = call;
+        Intent intent = PaywallActivity.newIntent(getActivity(), offering);
+        notifyListeners("paywallDisplayed", new JSObject());
+        paywallLauncher.launch(intent);
+    }
+    
+    private void handlePaywallResult(ActivityResult result) {
+        if (savedCall == null) {
+            return;
+        }
+        
+        if (result.getResultCode() == PaywallResult.PURCHASED.getResultCode()) {
+            JSObject jsObject = new JSObject();
+            jsObject.put("result", "PURCHASED");
+            savedCall.resolve(jsObject);
+        } else if (result.getResultCode() == PaywallResult.RESTORED.getResultCode()) {
+            JSObject jsObject = new JSObject();
+            jsObject.put("result", "RESTORED");
+            savedCall.resolve(jsObject);
+        } else if (result.getResultCode() == PaywallResult.CANCELLED.getResultCode()) {
+            JSObject jsObject = new JSObject();
+            jsObject.put("result", "CANCELLED");
+            savedCall.resolve(jsObject);
+        } else {
+            JSObject jsObject = new JSObject();
+            jsObject.put("result", "ERROR");
+            savedCall.resolve(jsObject);
+        }
+        
+        notifyListeners("paywallDismissed", new JSObject());
+        savedCall = null;
+    }
+} 

--- a/purchases-capacitor-ui/android/src/main/java/com/revenuecat/purchases/capacitor/ui/RevenueCatUIPlugin.java
+++ b/purchases-capacitor-ui/android/src/main/java/com/revenuecat/purchases/capacitor/ui/RevenueCatUIPlugin.java
@@ -56,114 +56,39 @@ public class RevenueCatUIPlugin extends Plugin {
     
     @PluginMethod
     public void presentPaywall(final PluginCall call) {
-        String offeringIdentifier = call.getString("offeringIdentifier");
+        // Gracefully handle unsupported feature on Android
+        JSObject result = new JSObject();
+        result.put("result", "NOT_PRESENTED");
+        call.resolve(result);
         
-        if (offeringIdentifier != null) {
-            Purchases.getSharedInstance().getOfferings(new Purchases.GetOfferingsListener() {
-                @Override
-                public void onReceived(Offerings offerings) {
-                    if (offerings.getOffering(offeringIdentifier) != null) {
-                        launchPaywall(offerings.getOffering(offeringIdentifier), call);
-                    } else {
-                        call.reject("Offering not found: " + offeringIdentifier);
-                    }
-                }
-                
-                @Override
-                public void onError(Exception error) {
-                    call.reject("Failed to get offerings: " + error.getMessage());
-                }
-            });
-        } else {
-            Purchases.getSharedInstance().getOfferings(new Purchases.GetOfferingsListener() {
-                @Override
-                public void onReceived(Offerings offerings) {
-                    if (offerings.getCurrentOffering() != null) {
-                        launchPaywall(offerings.getCurrentOffering(), call);
-                    } else {
-                        call.reject("No current offering found");
-                    }
-                }
-                
-                @Override
-                public void onError(Exception error) {
-                    call.reject("Failed to get offerings: " + error.getMessage());
-                }
-            });
-        }
+        // Log warning that this feature is not available on Android yet
+        getActivity().runOnUiThread(() -> {
+            Purchases.getSharedInstance().logMessage("RevenueCatUI warning: Paywalls are not supported on Android yet.");
+        });
     }
     
     @PluginMethod
     public void presentPaywallIfNeeded(final PluginCall call) {
-        String requiredEntitlementIdentifier = call.getString("requiredEntitlementIdentifier");
-        if (requiredEntitlementIdentifier == null) {
-            call.reject("Required entitlement identifier is missing");
-            return;
-        }
+        // Gracefully handle unsupported feature on Android
+        JSObject result = new JSObject();
+        result.put("result", "NOT_PRESENTED");
+        call.resolve(result);
         
-        Purchases.getSharedInstance().getCustomerInfo(new Purchases.GetCustomerInfoListener() {
-            @Override
-            public void onReceived(CustomerInfo customerInfo) {
-                if (customerInfo.getEntitlements().get(requiredEntitlementIdentifier) != null && 
-                    customerInfo.getEntitlements().get(requiredEntitlementIdentifier).isActive()) {
-                    JSObject result = new JSObject();
-                    result.put("result", "NOT_PRESENTED");
-                    call.resolve(result);
-                    return;
-                }
-                
-                String offeringIdentifier = call.getString("offeringIdentifier");
-                
-                if (offeringIdentifier != null) {
-                    Purchases.getSharedInstance().getOfferings(new Purchases.GetOfferingsListener() {
-                        @Override
-                        public void onReceived(Offerings offerings) {
-                            if (offerings.getOffering(offeringIdentifier) != null) {
-                                launchPaywall(offerings.getOffering(offeringIdentifier), call);
-                            } else if (offerings.getCurrentOffering() != null) {
-                                launchPaywall(offerings.getCurrentOffering(), call);
-                            } else {
-                                call.reject("No offering found");
-                            }
-                        }
-                        
-                        @Override
-                        public void onError(Exception error) {
-                            call.reject("Failed to get offerings: " + error.getMessage());
-                        }
-                    });
-                } else {
-                    Purchases.getSharedInstance().getOfferings(new Purchases.GetOfferingsListener() {
-                        @Override
-                        public void onReceived(Offerings offerings) {
-                            if (offerings.getCurrentOffering() != null) {
-                                launchPaywall(offerings.getCurrentOffering(), call);
-                            } else {
-                                call.reject("No current offering found");
-                            }
-                        }
-                        
-                        @Override
-                        public void onError(Exception error) {
-                            call.reject("Failed to get offerings: " + error.getMessage());
-                        }
-                    });
-                }
-            }
-            
-            @Override
-            public void onError(Exception error) {
-                call.reject("Failed to get customer info: " + error.getMessage());
-            }
+        // Log warning that this feature is not available on Android yet
+        getActivity().runOnUiThread(() -> {
+            Purchases.getSharedInstance().logMessage("RevenueCatUI warning: Paywalls are not supported on Android yet.");
         });
     }
     
     @PluginMethod
     public void presentCustomerCenter(PluginCall call) {
-        savedCall = call;
-        Intent intent = CustomerCenterActivity.newIntent(getActivity());
-        notifyListeners("paywallDisplayed", new JSObject());
-        customerCenterLauncher.launch(intent);
+        // Gracefully handle unsupported feature on Android
+        call.resolve();
+        
+        // Log warning that this feature is not available on Android yet
+        getActivity().runOnUiThread(() -> {
+            Purchases.getSharedInstance().logMessage("RevenueCatUI warning: Customer Center is not supported on Android yet.");
+        });
     }
     
     private void launchPaywall(com.revenuecat.purchases.Offering offering, PluginCall call) {

--- a/purchases-capacitor-ui/ios/Plugin/Plugin/RevenueCatUIPlugin.m
+++ b/purchases-capacitor-ui/ios/Plugin/Plugin/RevenueCatUIPlugin.m
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import <Capacitor/Capacitor.h>
+
+// Define the plugin using the CAP_PLUGIN Macro, and
+// each method the plugin supports using the CAP_PLUGIN_METHOD macro.
+CAP_PLUGIN(RevenueCatUIPlugin, "RevenueCatUI",
+           CAP_PLUGIN_METHOD(presentPaywall, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(presentPaywallIfNeeded, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(presentCustomerCenter, CAPPluginReturnPromise);
+) 

--- a/purchases-capacitor-ui/ios/Plugin/Plugin/RevenueCatUIPlugin.swift
+++ b/purchases-capacitor-ui/ios/Plugin/Plugin/RevenueCatUIPlugin.swift
@@ -8,56 +8,56 @@ import PurchasesHybridCommonUI
  */
 @objc(RevenueCatUIPlugin)
 public class RevenueCatUIPlugin: CAPPlugin {
-    
+
     // MARK: - Properties
-    
+
     private var savedCall: CAPPluginCall?
-    
+
     /// PaywallProxy for iOS 15.0+, will be nil on older iOS versions
     private var _paywallProxy: PaywallProxyType?
-    
+
     /// CustomerCenterProxy for iOS 15.0+, will be nil on older iOS versions
     private var _customerCenterProxy: CustomerCenterProxyType?
-    
+
     // MARK: - Initialization
-    
+
     override init() {
         super.init()
-        
+
         // Initialize proxies if iOS 15.0+ is available
         if #available(iOS 15.0, *) {
             _paywallProxy = PaywallProxy()
             _customerCenterProxy = CustomerCenterProxy()
         }
     }
-    
+
     // MARK: - Plugin Methods
-    
+
     @objc func presentPaywall(_ call: CAPPluginCall) {
         guard #available(iOS 15.0, *), let proxy = _paywallProxy else {
             call.reject("PaywallViewController requires iOS 15.0 or newer")
             return
         }
-        
+
         savedCall = call
-        
+
         let offeringIdentifier = call.getString("offeringIdentifier")
         let displayCloseButton = call.getBool("displayCloseButton") ?? false
-        
+
         var options: [String: Any] = [
             "displayCloseButton": displayCloseButton,
             "shouldBlockTouchEvents": true
         ]
-        
+
         if let offeringIdentifier = offeringIdentifier {
             options["offeringIdentifier"] = offeringIdentifier
         }
-        
+
         proxy.presentPaywall(
             options: options,
             paywallResultHandler: { [weak self] result in
                 guard let self = self else { return }
-                
+
                 if let call = self.savedCall {
                     call.resolve(["result": result])
                     self.savedCall = nil
@@ -65,38 +65,38 @@ public class RevenueCatUIPlugin: CAPPlugin {
             }
         )
     }
-    
+
     @objc func presentPaywallIfNeeded(_ call: CAPPluginCall) {
         guard #available(iOS 15.0, *), let proxy = _paywallProxy else {
             call.reject("PaywallViewController requires iOS 15.0 or newer")
             return
         }
-        
+
         savedCall = call
-        
+
         guard let requiredEntitlementIdentifier = call.getString("requiredEntitlementIdentifier") else {
             call.reject("Required entitlement identifier is missing")
             return
         }
-        
+
         let offeringIdentifier = call.getString("offeringIdentifier")
         let displayCloseButton = call.getBool("displayCloseButton") ?? false
-        
+
         var options: [String: Any] = [
             "displayCloseButton": displayCloseButton,
             "shouldBlockTouchEvents": true,
             "requiredEntitlementIdentifier": requiredEntitlementIdentifier
         ]
-        
+
         if let offeringIdentifier = offeringIdentifier {
             options["offeringIdentifier"] = offeringIdentifier
         }
-        
+
         proxy.presentPaywallIfNeeded(
             options: options,
             paywallResultHandler: { [weak self] result in
                 guard let self = self else { return }
-                
+
                 if let call = self.savedCall {
                     call.resolve(["result": result])
                     self.savedCall = nil
@@ -104,18 +104,18 @@ public class RevenueCatUIPlugin: CAPPlugin {
             }
         )
     }
-    
+
     @objc func presentCustomerCenter(_ call: CAPPluginCall) {
         guard #available(iOS 15.0, *), let proxy = _customerCenterProxy else {
             call.reject("CustomerCenterViewController requires iOS 15.0 or newer")
             return
         }
-        
+
         savedCall = call
-        
+
         proxy.present(resultHandler: { [weak self] in
             guard let self = self else { return }
-            
+
             if let call = self.savedCall {
                 call.resolve()
                 self.savedCall = nil
@@ -143,4 +143,4 @@ private protocol CustomerCenterProxyType: AnyObject {
 extension PaywallProxy: PaywallProxyType {}
 
 @available(iOS 15.0, *)
-extension CustomerCenterProxy: CustomerCenterProxyType {} 
+extension CustomerCenterProxy: CustomerCenterProxyType {}

--- a/purchases-capacitor-ui/ios/Plugin/Plugin/RevenueCatUIPlugin.swift
+++ b/purchases-capacitor-ui/ios/Plugin/Plugin/RevenueCatUIPlugin.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Capacitor
+import PurchasesHybridCommonUI
+
+/**
+ * RevenueCat UI Plugin for Capacitor
+ * Based on the official RevenueCat Flutter UI SDK approach
+ */
+@objc(RevenueCatUIPlugin)
+public class RevenueCatUIPlugin: CAPPlugin {
+    
+    // MARK: - Properties
+    
+    private var savedCall: CAPPluginCall?
+    
+    /// PaywallProxy for iOS 15.0+, will be nil on older iOS versions
+    private var _paywallProxy: PaywallProxyType?
+    
+    /// CustomerCenterProxy for iOS 15.0+, will be nil on older iOS versions
+    private var _customerCenterProxy: CustomerCenterProxyType?
+    
+    // MARK: - Initialization
+    
+    override init() {
+        super.init()
+        
+        // Initialize proxies if iOS 15.0+ is available
+        if #available(iOS 15.0, *) {
+            _paywallProxy = PaywallProxy()
+            _customerCenterProxy = CustomerCenterProxy()
+        }
+    }
+    
+    // MARK: - Plugin Methods
+    
+    @objc func presentPaywall(_ call: CAPPluginCall) {
+        guard #available(iOS 15.0, *), let proxy = _paywallProxy else {
+            call.reject("PaywallViewController requires iOS 15.0 or newer")
+            return
+        }
+        
+        savedCall = call
+        
+        let offeringIdentifier = call.getString("offeringIdentifier")
+        let displayCloseButton = call.getBool("displayCloseButton") ?? false
+        
+        var options: [String: Any] = [
+            "displayCloseButton": displayCloseButton,
+            "shouldBlockTouchEvents": true
+        ]
+        
+        if let offeringIdentifier = offeringIdentifier {
+            options["offeringIdentifier"] = offeringIdentifier
+        }
+        
+        proxy.presentPaywall(
+            options: options,
+            paywallResultHandler: { [weak self] result in
+                guard let self = self else { return }
+                
+                if let call = self.savedCall {
+                    call.resolve(["result": result])
+                    self.savedCall = nil
+                }
+            }
+        )
+    }
+    
+    @objc func presentPaywallIfNeeded(_ call: CAPPluginCall) {
+        guard #available(iOS 15.0, *), let proxy = _paywallProxy else {
+            call.reject("PaywallViewController requires iOS 15.0 or newer")
+            return
+        }
+        
+        savedCall = call
+        
+        guard let requiredEntitlementIdentifier = call.getString("requiredEntitlementIdentifier") else {
+            call.reject("Required entitlement identifier is missing")
+            return
+        }
+        
+        let offeringIdentifier = call.getString("offeringIdentifier")
+        let displayCloseButton = call.getBool("displayCloseButton") ?? false
+        
+        var options: [String: Any] = [
+            "displayCloseButton": displayCloseButton,
+            "shouldBlockTouchEvents": true,
+            "requiredEntitlementIdentifier": requiredEntitlementIdentifier
+        ]
+        
+        if let offeringIdentifier = offeringIdentifier {
+            options["offeringIdentifier"] = offeringIdentifier
+        }
+        
+        proxy.presentPaywallIfNeeded(
+            options: options,
+            paywallResultHandler: { [weak self] result in
+                guard let self = self else { return }
+                
+                if let call = self.savedCall {
+                    call.resolve(["result": result])
+                    self.savedCall = nil
+                }
+            }
+        )
+    }
+    
+    @objc func presentCustomerCenter(_ call: CAPPluginCall) {
+        guard #available(iOS 15.0, *), let proxy = _customerCenterProxy else {
+            call.reject("CustomerCenterViewController requires iOS 15.0 or newer")
+            return
+        }
+        
+        savedCall = call
+        
+        proxy.present(resultHandler: { [weak self] in
+            guard let self = self else { return }
+            
+            if let call = self.savedCall {
+                call.resolve()
+                self.savedCall = nil
+            }
+        })
+    }
+}
+
+// MARK: - Type Aliases to avoid direct type references
+
+/// Type alias for PaywallProxy to avoid direct reference to the concrete type
+private protocol PaywallProxyType: AnyObject {
+    func presentPaywall(options: [String: Any], paywallResultHandler: @escaping (String) -> Void)
+    func presentPaywallIfNeeded(options: [String: Any], paywallResultHandler: @escaping (String) -> Void)
+}
+
+/// Type alias for CustomerCenterProxy to avoid direct reference to the concrete type
+private protocol CustomerCenterProxyType: AnyObject {
+    func present(resultHandler: @escaping () -> Void)
+}
+
+// MARK: - Proxy Conformances
+
+@available(iOS 15.0, *)
+extension PaywallProxy: PaywallProxyType {}
+
+@available(iOS 15.0, *)
+extension CustomerCenterProxy: CustomerCenterProxyType {} 

--- a/purchases-capacitor-ui/package.json
+++ b/purchases-capacitor-ui/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@revenuecat/purchases-capacitor-ui",
+  "version": "10.2.4",
+  "description": "UI components for RevenueCat Capacitor SDK",
+  "main": "dist/plugin.cjs.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "unpkg": "dist/plugin.js",
+  "files": [
+    "android/src/main/",
+    "android/build.gradle",
+    "dist/",
+    "ios/Plugin/",
+    "PurchasesCapacitorUi.podspec"
+  ],
+  "author": "RevenueCat, Inc.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RevenueCat/purchases-capacitor.git"
+  },
+  "bugs": {
+    "url": "https://github.com/RevenueCat/purchases-capacitor/issues"
+  },
+  "keywords": [
+    "capacitor",
+    "plugin",
+    "native",
+    "revenuecat",
+    "purchases",
+    "subscriptions",
+    "iap",
+    "in-app-purchases",
+    "ui",
+    "paywall",
+    "customer-center"
+  ],
+  "capacitor": {
+    "ios": {
+      "src": "ios"
+    },
+    "android": {
+      "src": "android"
+    }
+  },
+  "scripts": {
+    "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
+    "verify:ios": "cd ios && pod install && xcodebuild -workspace Plugin.xcworkspace -scheme Plugin -destination generic/platform=iOS && cd ..",
+    "verify:android": "cd android && ./gradlew clean build test && cd ..",
+    "verify:web": "npm run build",
+    "lint": "npm run eslint && npm run prettier -- --check",
+    "fmt": "npm run eslint -- --fix && npm run prettier -- --write",
+    "eslint": "eslint . --ext ts",
+    "prettier": "prettier \"**/*.{css,html,js,java,json,md,ts,tsx}\"",
+    "docgen": "docgen --api RevenueCatUIPlugin --output-readme README.md",
+    "build": "npm run clean && tsc && rollup -c ../rollup.config.js",
+    "clean": "rimraf ./dist",
+    "watch": "tsc --watch",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@capacitor/core": "^7.0.0",
+    "@revenuecat/purchases-capacitor": "^10.2.4"
+  },
+  "peerDependencies": {
+    "@capacitor/core": "^7.0.0"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^7.0.0",
+    "@capacitor/docgen": "^0.3.0",
+    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/prettier-config": "^4.0.0",
+    "eslint": "^8.57.0",
+    "prettier": "^3.4.2",
+    "prettier-plugin-java": "^2.6.6",
+    "rimraf": "^6.0.1",
+    "rollup": "^4.30.1",
+    "typescript": "~4.1.5"
+  }
+} 

--- a/purchases-capacitor-ui/src/definitions.ts
+++ b/purchases-capacitor-ui/src/definitions.ts
@@ -1,0 +1,93 @@
+import type { PluginListenerHandle } from '@capacitor/core';
+
+export interface RevenueCatUIPlugin {
+  /**
+   * Presents a paywall configured in the RevenueCat dashboard.
+   * @param options The options for presenting the paywall.
+   * @returns A PaywallResult indicating what happened during the paywall presentation.
+   */
+  presentPaywall(options?: PresentPaywallOptions): Promise<PaywallResult>;
+
+  /**
+   * Presents a paywall only if the user does not have the specified entitlement.
+   * @param options The options for presenting the paywall if needed.
+   * @returns A PaywallResult indicating what happened during the paywall presentation.
+   */
+  presentPaywallIfNeeded(options: PresentPaywallIfNeededOptions): Promise<PaywallResult>;
+
+  /**
+   * Presents the customer center where users can manage their subscriptions.
+   */
+  presentCustomerCenter(): Promise<void>;
+
+  /**
+   * Listen for when a paywall is displayed or dismissed.
+   * @param eventName The event to listen for
+   * @param listener The listener to call when the event is triggered
+   */
+  addListener(
+    eventName: 'paywallDisplayed' | 'paywallDismissed',
+    listener: () => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Remove all listeners for this plugin.
+   */
+  removeAllListeners(): Promise<void>;
+}
+
+export interface PresentPaywallOptions {
+  /**
+   * The identifier of the offering to present.
+   * If not provided, the current offering will be used.
+   */
+  offeringIdentifier?: string;
+
+  /**
+   * Whether to display a close button on the paywall.
+   * Only applicable for original template paywalls, ignored for V2 Paywalls.
+   */
+  displayCloseButton?: boolean;
+}
+
+export interface PresentPaywallIfNeededOptions extends PresentPaywallOptions {
+  /**
+   * The identifier of the entitlement that is required.
+   * The paywall will only be presented if the user doesn't have this entitlement.
+   */
+  requiredEntitlementIdentifier: string;
+}
+
+export enum PaywallResultEnum {
+  /**
+   * The paywall wasn't presented because the user already has the required entitlement.
+   */
+  NOT_PRESENTED = 'NOT_PRESENTED',
+
+  /**
+   * The user cancelled the paywall without purchasing anything.
+   */
+  CANCELLED = 'CANCELLED',
+
+  /**
+   * An error occurred while presenting the paywall.
+   */
+  ERROR = 'ERROR',
+
+  /**
+   * The user made a purchase.
+   */
+  PURCHASED = 'PURCHASED',
+
+  /**
+   * The user restored a previous purchase.
+   */
+  RESTORED = 'RESTORED',
+}
+
+export interface PaywallResult {
+  /**
+   * The result of the paywall presentation.
+   */
+  result: PaywallResultEnum;
+} 

--- a/purchases-capacitor-ui/src/definitions.ts
+++ b/purchases-capacitor-ui/src/definitions.ts
@@ -25,10 +25,7 @@ export interface RevenueCatUIPlugin {
    * @param eventName The event to listen for
    * @param listener The listener to call when the event is triggered
    */
-  addListener(
-    eventName: 'paywallDisplayed' | 'paywallDismissed',
-    listener: () => void,
-  ): Promise<PluginListenerHandle>;
+  addListener(eventName: 'paywallDisplayed' | 'paywallDismissed', listener: () => void): Promise<PluginListenerHandle>;
 
   /**
    * Remove all listeners for this plugin.
@@ -90,4 +87,4 @@ export interface PaywallResult {
    * The result of the paywall presentation.
    */
   result: PaywallResultEnum;
-} 
+}

--- a/purchases-capacitor-ui/src/index.ts
+++ b/purchases-capacitor-ui/src/index.ts
@@ -1,0 +1,10 @@
+import { registerPlugin } from '@capacitor/core';
+
+import type { RevenueCatUIPlugin } from './definitions';
+
+const RevenueCatUI = registerPlugin<RevenueCatUIPlugin>('RevenueCatUI', {
+  web: () => import('./web').then(m => new m.RevenueCatUIWeb()),
+});
+
+export * from './definitions';
+export { RevenueCatUI }; 

--- a/purchases-capacitor-ui/src/index.ts
+++ b/purchases-capacitor-ui/src/index.ts
@@ -3,8 +3,8 @@ import { registerPlugin } from '@capacitor/core';
 import type { RevenueCatUIPlugin } from './definitions';
 
 const RevenueCatUI = registerPlugin<RevenueCatUIPlugin>('RevenueCatUI', {
-  web: () => import('./web').then(m => new m.RevenueCatUIWeb()),
+  web: () => import('./web').then((m) => new m.RevenueCatUIWeb()),
 });
 
 export * from './definitions';
-export { RevenueCatUI }; 
+export { RevenueCatUI };

--- a/purchases-capacitor-ui/src/web.ts
+++ b/purchases-capacitor-ui/src/web.ts
@@ -1,11 +1,14 @@
-import { WebPlugin, type PluginListenerHandle } from '@capacitor/core';
+import { WebPlugin } from '@capacitor/core';
+import type { PluginListenerHandle } from '@capacitor/core';
 
 import { 
   PaywallResultEnum,
-  type PaywallResult,
-  type PresentPaywallIfNeededOptions, 
-  type PresentPaywallOptions, 
-  type RevenueCatUIPlugin 
+} from './definitions';
+import type {
+  PaywallResult,
+  PresentPaywallIfNeededOptions,
+  PresentPaywallOptions,
+  RevenueCatUIPlugin
 } from './definitions';
 
 export class RevenueCatUIWeb extends WebPlugin implements RevenueCatUIPlugin {

--- a/purchases-capacitor-ui/src/web.ts
+++ b/purchases-capacitor-ui/src/web.ts
@@ -45,9 +45,12 @@ export class RevenueCatUIWeb extends WebPlugin implements RevenueCatUIPlugin {
   }
 
   addListener(
-    eventName: 'paywallDisplayed' | 'paywallDismissed', 
-    listener: () => void
+    eventName: string,
+    listener: (...args: any[]) => void
   ): Promise<PluginListenerHandle> {
+    if (eventName !== 'paywallDisplayed' && eventName !== 'paywallDismissed') {
+      console.warn(`Unsupported event: ${eventName}`);
+    }
     return super.addListener(eventName, listener);
   }
 

--- a/purchases-capacitor-ui/src/web.ts
+++ b/purchases-capacitor-ui/src/web.ts
@@ -1,0 +1,54 @@
+import { WebPlugin, type PluginListenerHandle } from '@capacitor/core';
+
+import { 
+  PaywallResultEnum,
+  type PaywallResult,
+  type PresentPaywallIfNeededOptions, 
+  type PresentPaywallOptions, 
+  type RevenueCatUIPlugin 
+} from './definitions';
+
+export class RevenueCatUIWeb extends WebPlugin implements RevenueCatUIPlugin {
+  constructor() {
+    super();
+  }
+
+  async presentPaywall(options?: PresentPaywallOptions): Promise<PaywallResult> {
+    console.warn(
+      'RevenueCatUI.presentPaywall is not implemented on web',
+      options
+    );
+    
+    return {
+      result: PaywallResultEnum.NOT_PRESENTED,
+    };
+  }
+
+  async presentPaywallIfNeeded(options: PresentPaywallIfNeededOptions): Promise<PaywallResult> {
+    console.warn(
+      'RevenueCatUI.presentPaywallIfNeeded is not implemented on web',
+      options
+    );
+    
+    return {
+      result: PaywallResultEnum.NOT_PRESENTED,
+    };
+  }
+
+  async presentCustomerCenter(): Promise<void> {
+    console.warn(
+      'RevenueCatUI.presentCustomerCenter is not implemented on web'
+    );
+  }
+
+  addListener(
+    eventName: 'paywallDisplayed' | 'paywallDismissed', 
+    listener: () => void
+  ): Promise<PluginListenerHandle> {
+    return super.addListener(eventName, listener);
+  }
+
+  removeAllListeners(): Promise<void> {
+    return super.removeAllListeners();
+  }
+} 

--- a/purchases-capacitor-ui/src/web.ts
+++ b/purchases-capacitor-ui/src/web.ts
@@ -1,14 +1,12 @@
 import { WebPlugin } from '@capacitor/core';
 import type { PluginListenerHandle } from '@capacitor/core';
 
-import { 
-  PaywallResultEnum,
-} from './definitions';
+import { PaywallResultEnum } from './definitions';
 import type {
   PaywallResult,
   PresentPaywallIfNeededOptions,
   PresentPaywallOptions,
-  RevenueCatUIPlugin
+  RevenueCatUIPlugin,
 } from './definitions';
 
 export class RevenueCatUIWeb extends WebPlugin implements RevenueCatUIPlugin {
@@ -17,37 +15,26 @@ export class RevenueCatUIWeb extends WebPlugin implements RevenueCatUIPlugin {
   }
 
   async presentPaywall(options?: PresentPaywallOptions): Promise<PaywallResult> {
-    console.warn(
-      'RevenueCatUI.presentPaywall is not implemented on web',
-      options
-    );
-    
+    console.warn('RevenueCatUI.presentPaywall is not implemented on web', options);
+
     return {
       result: PaywallResultEnum.NOT_PRESENTED,
     };
   }
 
   async presentPaywallIfNeeded(options: PresentPaywallIfNeededOptions): Promise<PaywallResult> {
-    console.warn(
-      'RevenueCatUI.presentPaywallIfNeeded is not implemented on web',
-      options
-    );
-    
+    console.warn('RevenueCatUI.presentPaywallIfNeeded is not implemented on web', options);
+
     return {
       result: PaywallResultEnum.NOT_PRESENTED,
     };
   }
 
   async presentCustomerCenter(): Promise<void> {
-    console.warn(
-      'RevenueCatUI.presentCustomerCenter is not implemented on web'
-    );
+    console.warn('RevenueCatUI.presentCustomerCenter is not implemented on web');
   }
 
-  addListener(
-    eventName: string,
-    listener: (...args: any[]) => void
-  ): Promise<PluginListenerHandle> {
+  addListener(eventName: string, listener: (...args: any[]) => void): Promise<PluginListenerHandle> {
     if (eventName !== 'paywallDisplayed' && eventName !== 'paywallDismissed') {
       console.warn(`Unsupported event: ${eventName}`);
     }
@@ -57,4 +44,4 @@ export class RevenueCatUIWeb extends WebPlugin implements RevenueCatUIPlugin {
   removeAllListeners(): Promise<void> {
     return super.removeAllListeners();
   }
-} 
+}

--- a/purchases-capacitor-ui/tsconfig.json
+++ b/purchases-capacitor-ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "allowUnreachableCode": false,
+    "declaration": true,
+    "esModuleInterop": true,
+    "inlineSources": true,
+    "lib": ["dom", "es2017"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "dist/esm",
+    "pretty": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2017"
+  },
+  "files": ["src/index.ts"]
+} 


### PR DESCRIPTION
Thank you for contributing to RevenueCat/purchases-capacitor. Before pressing the "Create Pull Request" button, please provide the following:


I did this PR Vibe Coding fragments but controlling the overall structure and methods. I hope is helpful. ☺️

  - [ ] A description about what and why you are contributing, even if it's trivial.
  
 This PR adds support for PresentPaywall on iOS in the purchases-capacitor-ui plugin.
  
We focused only on iOS paywalls because several customers are waiting for this feature in Capacitor apps.

To avoid modifying the HybridCommon repository, we used method swizzling to work around thread security issues (solution proposed by Claude 3.7).

All changes are contained within the purchases-capacitor-ui folder.

For Customer Center on iOS, the same technique could not be applied.

Android support is not included due to significant differences between Capacitor’s internal Cordova implementation and our paywall requirements (also diagnosed with Claude 3.7).

  - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [ ] If applicable, unit tests.
  
  No new unit tests are included.
  
Manual testing was performed on iOS Simulator and via TestFlight. (A video can be attached if needed.)
