### PR TITLE
Fix UI package bundled files reference

### DIFF
--- a/purchases-capacitor-ui/package.json
+++ b/purchases-capacitor-ui/package.json
@@ -11,7 +11,7 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "PurchasesCapacitorUi.podspec"
+    "RevenuecatPurchasesCapacitorUI.podspec"
   ],
   "author": "RevenueCat, Inc.",
   "license": "MIT",


### PR DESCRIPTION
The last release didn't correctly include the podspec file, potentially causing issues for users using iOS and our UI package. This fixes that.
