### PR TITLE
Export `PAYWALL_RESULT` from UI library

### DIFF
--- a/purchases-capacitor-ui/src/index.ts
+++ b/purchases-capacitor-ui/src/index.ts
@@ -7,4 +7,5 @@ const RevenueCatUI = registerPlugin<RevenueCatUIPlugin>('RevenueCatUI', {
 });
 
 export * from './definitions';
+export { PAYWALL_RESULT } from '@revenuecat/purchases-typescript-internal-esm';
 export { RevenueCatUI };


### PR DESCRIPTION
We were not exporting `PAYWALL_RESULT` from the `@revenuecat/purchases-capacitor-ui` library, even though it's part of the API. It was still accessible as part of the `@revenuecat/purchases-capacitor`. However, the API surface for the ui library should be complete. This fixes that.

Note that we still haven't added API tests/api generation to the capacitor library. We should do that but that seems like a separate PR.