### PR TITLE
Prevent release branches from running test jobs twice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,11 +271,12 @@ jobs:
 
 workflows:
   version: 2
-  build-test:
+  build-test-hold-deploy:
     when:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
+      # Testing phase - runs on all branches
       - run-tests-ios
       - run-tests-android
       - run-lint
@@ -284,20 +285,7 @@ workflows:
       - run-lint-ui
       - dry-run-release-ui
 
-  deploy:
-    when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-    jobs:
-      - run-tests-ios:
-          <<: *release-branches
-      - run-tests-android:
-          <<: *release-branches
-      - run-lint:
-          <<: *release-branches
-      # UI Package jobs for release branches
-      - run-lint-ui:
-          <<: *release-branches
+      # Hold and deploy phase - only on release branches
       - hold:
           type: approval
           requires:


### PR DESCRIPTION
In release branches, `run-tests-ios`, `run-tests-android` and the other jobs that were both in `build-test` and `deploy` were running twice. 

See https://app.circleci.com/pipelines/github/RevenueCat/purchases-capacitor?branch=release/10.3.8

<img width="1202" height="749" alt="Screenshot 2025-07-16 at 15 43 05" src="https://github.com/user-attachments/assets/caf811e9-351d-4c0c-ad1e-bfe2c22e25dd" />

We could set `build-test` to only run on non-release, but to avoid duplication I decided to just create a `build-test-hold-deploy`