### PR TITLE
[v10] Prepare for next release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,8 +286,14 @@ workflows:
 
   deploy:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        # Only run this workflow when the action is "build" (the default), 
+        # so it doesn't run for other actions like "bump" on a release branch,
+        # which should only open the release PR but not deploy it.
+        # (Deployment happens after the hold job is approved on the release PR.)
+        - equal: [ build, << pipeline.parameters.action >> ]
     jobs:
       - run-tests-ios:
           <<: *release-branches

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 05ef0952ecb3b92398a0185a3f74019abd0c1d95
+  revision: 1593f78d0b9b24b48238337666183e3ba82f848e
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri
@@ -267,10 +267,10 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     logger (1.7.0)
-    mime-types (3.6.0)
+    mime-types (3.7.0)
       logger
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0304)
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0924)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.1)
@@ -283,9 +283,9 @@ GEM
     naturally (2.2.2)
     netrc (0.11.0)
     nkf (0.2.0)
-    nokogiri (1.18.8-arm64-darwin)
+    nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (10.0.0)
       faraday (>= 1, < 3)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -59,7 +59,8 @@ desc "Automatically bumps version, edit changelog, and create pull request"
 lane :automatic_bump do |options|
   next_version, type_of_bump = determine_next_version_using_labels(
     repo_name: repo_name,
-    github_rate_limit: options[:github_rate_limit]
+    github_rate_limit: options[:github_rate_limit],
+    current_version: current_version_number
   )
   options[:next_version] = next_version
   options[:automatic_release] = true


### PR DESCRIPTION
This PR makes the changes needed for the next release of v10.

* Bump [fastlane-plugin-revenuecat_internal](https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal) from `05ef095 ` to `1593f78`. See full diff in <a href="https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/compare/05ef0952ecb3b92398a0185a3f74019abd0c1d95...1593f78d0b9b24b48238337666183e3ba82f848e">compare view</a>.
* Pass current version in automatic bump.
* [CI] Only `build` pipeline action can trigger `on-release-branch` workflow.