### PR TITLE
[v10] Update fastlane plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
       - yarn-dependencies-unix
       - run:
           name: Create automatic PR
-          command: bundle exec fastlane automatic_bump github_rate_limit:10
+          command: bundle exec fastlane automatic_bump
 
   # UI Package Jobs
   run-lint-ui:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 1593f78d0b9b24b48238337666183e3ba82f848e
+  revision: 7508f173ab5224816b52fdfaf8efe5d433c471a1
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri


### PR DESCRIPTION
This PR makes bumps [fastlane-plugin-revenuecat_internal](https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal) from `1593f78` to `7508f17`. See full diff in <a href="https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/compare/1593f78d0b9b24b48238337666183e3ba82f848e...7508f173ab5224816b52fdfaf8efe5d433c471a1">compare view</a>.

In addition, it removes the use of the `github_rate_limit` parameter from `automatic_bump` fastlane lane, as it's not needed anymore.