### PR TITLE
[v10] Update fastlane plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 7508f173ab5224816b52fdfaf8efe5d433c471a1
+  revision: 3f7fffc2e3111e92d2ad86e7c2644743bde69119
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri


### PR DESCRIPTION
This PR makes bumps [fastlane-plugin-revenuecat_internal](https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal) from `7508f17` to `3f7fffc`. See full diff in <a href="https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/compare/7508f173ab5224816b52fdfaf8efe5d433c471a1...3f7fffc2e3111e92d2ad86e7c2644743bde69119">compare view</a>.