### PR TITLE
Fix passing offering to `presentPaywall` functions

### DIFF
--- a/purchases-capacitor-ui/ios/Plugin/Plugin/RevenueCatUIPlugin.swift
+++ b/purchases-capacitor-ui/ios/Plugin/Plugin/RevenueCatUIPlugin.swift
@@ -145,7 +145,7 @@ private extension RevenueCatUIPlugin {
 
     func processOfferingOptions(_ call: CAPPluginCall) -> [String: Any]? {
         let offering = call.getObject("offering")
-        let offeringIdentifier = call.getString("offeringIdentifier")
+        let offeringIdentifier = offering?["identifier"] as? String
         let availablePackages = offering?["availablePackages"] as? JSArray
         let firstPackage = availablePackages?.first as? JSObject
         let presentedOfferingContext = firstPackage?["presentedOfferingContext"] as? JSObject


### PR DESCRIPTION
This broke in #524. We were incorrectly parsing the offering Identifier in iOS native, which caused it to always show the default offering, instead of the passed parameter. This was reported in #568.
