### PR TITLE
fix(purchase-tester): repair build-purchase-tester TypeScript error

### DIFF
--- a/example/purchase-tester/src/components/FunctionTesterContainer.tsx
+++ b/example/purchase-tester/src/components/FunctionTesterContainer.tsx
@@ -1039,7 +1039,7 @@ const FunctionTesterContainer: React.FC<ContainerProps> = () => {
 
     const result = await RevenueCatUI.presentPaywallIfNeeded({
       requiredEntitlementIdentifier: 'pro',
-      offering,
+      offering: offering ?? undefined,
       listener,
       customVariables: resolvedCustomVariables,
     });


### PR DESCRIPTION
## Summary

After #748, `yarn build` in the purchase-tester example failed TypeScript checking: `presentPaywallIfNeededWithListener` passed `offering` from `getConfiguredOffering()`, which is typed as `PurchasesOffering | null`, but `PresentPaywallIfNeededOptions` only allows `offering?: PurchasesOffering` (i.e. `undefined`, not `null`).

## What changed

- Pass `offering: offering ?? undefined` so the optional property matches the public API types. Runtime behavior is unchanged: when there is no configured offering, the property is omitted and the native SDK uses the current offering (as intended for the IfNeeded flow).

## Related

- Fixes CI job `build-purchase-tester` (regressed after #748).

---

- [x] A description about what and why you are contributing, even if it is trivial.
- [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those. (#748)
- [x] If applicable, unit tests. (N/A — sample app TypeScript fix only)
