### PR TITLE
ci: add typecheck-purchase-tester job to catch TypeScript errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,24 @@ jobs:
       - run: yarn build
       - run: yarn lint
 
+  typecheck-purchase-tester:
+    description: "Build the purchase-tester web app to catch TypeScript errors"
+    docker:
+      - image: cimg/ruby:3.1.2
+    steps:
+      - checkout
+      - yarn-dependencies-unix
+      - yarn-dependencies-ui-unix
+      - run:
+          name: Build main package
+          command: yarn build
+      - run:
+          name: Build UI package
+          command: cd purchases-capacitor-ui && npm run build
+      - run:
+          name: Build purchase tester
+          command: cd example/purchase-tester && yarn && yarn build
+
   make-release:
     description: "Publishes the new version and creates a github release"
     <<: *base-mac-job
@@ -333,6 +351,7 @@ workflows:
       - run-tests-android
       - run-lint
       - build-purchase-tester
+      - typecheck-purchase-tester
       # API change detection
       - check-api-changes
       # UI Package jobs


### PR DESCRIPTION
## Summary

- Adds a `typecheck-purchase-tester` CircleCI job that builds the purchase-tester web app (including `tsc`) on every PR
- Runs on a Linux Docker container — fast and cheap compared to the existing Mac `build-purchase-tester` job
- Builds root package → UI package → purchase-tester in sequence, mirroring what the fastlane lane does
- Closes the gap exposed by #751, where a TypeScript error in the example app slipped through undetected

## Test plan

- [ ] Verify the new job appears in CircleCI on this PR
- [ ] (Optional) Add `typecheck-purchase-tester` as a required status check in GitHub branch protection settings for `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)