### PR TITLE
Update CODEOWNERS default owner to @RevenueCat/sdk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # CODEOWNERS for purchases-capacitor
 
 # Default owners
-* @RevenueCat/coresdk
+* @RevenueCat/sdk


### PR DESCRIPTION
## Summary
- Update the default code owner from `@RevenueCat/coresdk` to `@RevenueCat/sdk`
- The "Require review from Code Owners" branch protection setting is being enabled organization-wide. Since `@RevenueCat/coresdk` is a small team, this would create a bottleneck. Widening the designated code owner to the broader `@RevenueCat/sdk` team ensures PRs won't be blocked while still requiring a team member's approval.

## Test plan
- [x] Verify CODEOWNERS file syntax is valid