### PR TITLE
Add retry mechanism to Maestro e2e tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: ca2b191e4584a46a5fa9ad4b418af0f56a338cd3
+  revision: d1e580865d34d9a50c7429d0316a6e75f4873d9d
   branch: pallares/maestro-retry
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: d1e580865d34d9a50c7429d0316a6e75f4873d9d
-  branch: pallares/maestro-retry
+  revision: a1eed48467a057a8bbdac5a0587e3653a541a46b
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 6289be1dcdf7efc57682b284be9bdb1db3efbe69
+  revision: ca2b191e4584a46a5fa9ad4b418af0f56a338cd3
+  branch: pallares/maestro-retry
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri
@@ -280,7 +281,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0331)
+    mime-types-data (3.2026.0414)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.27.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -255,8 +255,7 @@ lane :run_maestro_e2e_tests_ios do
     sh("xcodebuild -project ios/App/App.xcodeproj -scheme App -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath build")
     sh("xcrun simctl install booted build/Build/Products/Debug-iphonesimulator/App.app")
   end
-  sh("mkdir -p test_output")
-  sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/")
+  run_maestro_with_retries(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
 end
 
 desc "Build maestro E2E test app for Android"
@@ -277,8 +276,7 @@ end
 desc "Run maestro E2E tests on Android (emulator must be running)"
 lane :run_maestro_e2e_tests_android do
   sh("adb install ../e2e-tests/MaestroTestApp/android/app/build/outputs/apk/debug/app-debug.apk")
-  sh("mkdir -p test_output")
-  sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/")
+  run_maestro_with_retries(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
 end
 
 desc "Tag current branch with current version number"
@@ -288,6 +286,32 @@ lane :tag_current_branch do |options|
 
   add_git_tag(tag: version_number)
   push_git_tags(tag: version_number)
+end
+
+def run_maestro_with_retries(flow_dir:, output_dir:)
+  max_retries = 5
+  attempt = 0
+  success = false
+
+  FileUtils.mkdir_p(output_dir)
+
+  while attempt <= max_retries && !success
+    attempt_output_dir = "#{output_dir}/attempt_#{attempt}"
+    FileUtils.mkdir_p(attempt_output_dir)
+
+    begin
+      sh("maestro", "test", "--format", "junit", "--output", "#{attempt_output_dir}/report.xml", "--test-output-dir", attempt_output_dir, flow_dir)
+      success = true
+      FileUtils.cp("#{attempt_output_dir}/report.xml", "#{output_dir}/report.xml")
+    rescue => e
+      UI.error("Maestro test attempt #{attempt} failed: #{e.message}")
+      if attempt >= max_retries
+        raise e
+      end
+      attempt += 1
+      UI.message("Retrying... #{attempt}/#{max_retries}")
+    end
+  end
 end
 
 ###############################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -255,7 +255,7 @@ lane :run_maestro_e2e_tests_ios do
     sh("xcodebuild -project ios/App/App.xcodeproj -scheme App -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath build")
     sh("xcrun simctl install booted build/Build/Products/Debug-iphonesimulator/App.app")
   end
-  run_maestro_with_retries(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
+  run_maestro_e2e_tests(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
 end
 
 desc "Build maestro E2E test app for Android"
@@ -276,7 +276,7 @@ end
 desc "Run maestro E2E tests on Android (emulator must be running)"
 lane :run_maestro_e2e_tests_android do
   sh("adb install ../e2e-tests/MaestroTestApp/android/app/build/outputs/apk/debug/app-debug.apk")
-  run_maestro_with_retries(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
+  run_maestro_e2e_tests(flow_dir: "../e2e-tests/maestro/", output_dir: "test_output")
 end
 
 desc "Tag current branch with current version number"
@@ -286,32 +286,6 @@ lane :tag_current_branch do |options|
 
   add_git_tag(tag: version_number)
   push_git_tags(tag: version_number)
-end
-
-def run_maestro_with_retries(flow_dir:, output_dir:)
-  max_retries = 5
-  attempt = 0
-  success = false
-
-  FileUtils.mkdir_p(output_dir)
-
-  while attempt <= max_retries && !success
-    attempt_output_dir = "#{output_dir}/attempt_#{attempt}"
-    FileUtils.mkdir_p(attempt_output_dir)
-
-    begin
-      sh("maestro", "test", "--format", "junit", "--output", "#{attempt_output_dir}/report.xml", "--test-output-dir", attempt_output_dir, flow_dir)
-      success = true
-      FileUtils.cp("#{attempt_output_dir}/report.xml", "#{output_dir}/report.xml")
-    rescue => e
-      UI.error("Maestro test attempt #{attempt} failed: #{e.message}")
-      if attempt >= max_retries
-        raise e
-      end
-      attempt += 1
-      UI.message("Retrying... #{attempt}/#{max_retries}")
-    end
-  end
 end
 
 ###############################################################################

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem "fastlane-plugin-revenuecat_internal", git: "https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal"
+gem "fastlane-plugin-revenuecat_internal", git: "https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal", branch: "pallares/maestro-retry"

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem "fastlane-plugin-revenuecat_internal", git: "https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal", branch: "pallares/maestro-retry"
+gem "fastlane-plugin-revenuecat_internal", git: "https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal"


### PR DESCRIPTION
## Summary
- Replaces inline retry logic with the shared `run_maestro_e2e_tests` action from `fastlane-plugin-revenuecat_internal`
- The plugin action handles up to 6 attempts with per-attempt output directories for debugging

## Test plan
- [ ] Verify Maestro e2e tests CI job runs successfully
- [ ] Confirm JUnit reports are correctly stored as artifacts