### PR TITLE
Expose RevenueCatUI layout direction opt-in

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,4 +1,7 @@
 ## RevenueCat SDK
+### ✨ New Features
+* `RevenueCatUI` Paywalls and Customer Center can now opt in to matching right-to-left layout when overriding the preferred UI locale by setting `preferredUILocaleOverrideHonorsLayoutDirection` at configure time or `honorLayoutDirection` at runtime. The default remains false to preserve existing layout behavior.
+
 ### 📦 Dependency Updates
 * [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.1.0 (#765) via RevenueCat Git Bot (@RCGitBot)
   * [Android 10.2.0](https://github.com/RevenueCat/purchases-android/releases/tag/10.2.0)

--- a/README.md
+++ b/README.md
@@ -1401,11 +1401,11 @@ The EntitlementInfo object gives you access to all of the information about the 
 
 Represents a non-subscription transaction in the <a href="#store">Store</a>.
 
-| Prop                        | Type                | Description                                          |
-| --------------------------- | ------------------- | ---------------------------------------------------- |
-| **`transactionIdentifier`** | <code>string</code> | Id of the transaction.                               |
-| **`productIdentifier`**     | <code>string</code> | Product Id associated with the transaction.          |
-| **`purchaseDate`**          | <code>string</code> | Purchase date of the transaction in ISO 8601 format. |
+| Prop                        | Type                        | Description                                          |
+| --------------------------- | --------------------------- | ---------------------------------------------------- |
+| **`transactionIdentifier`** | <code>string</code>         | Id of the transaction.                               |
+| **`productIdentifier`**     | <code>string</code>         | Product Id associated with the transaction.          |
+| **`purchaseDate`**          | <code>string</code>         | Purchase date of the transaction in ISO 8601 format. |
 | **`purchaseToken`**         | <code>string \| null</code> | Purchase token of the transaction. Android only.     |
 
 

--- a/README.md
+++ b/README.md
@@ -137,14 +137,14 @@ This plugin is based on [CapGo's Capacitor plugin](https://www.npmjs.com/package
 ### configure(...)
 
 ```typescript
-configure(configuration: PurchasesConfiguration) => Promise<void>
+configure(configuration: PurchasesConfigurationWithLayoutDirection) => Promise<void>
 ```
 
 Sets up Purchases with your API key and an app user id.
 
-| Param               | Type                                                                      | Description                                                                                                                                                   |
-| ------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`configuration`** | <code><a href="#purchasesconfiguration">PurchasesConfiguration</a></code> | RevenueCat configuration object including the API key and other optional parameters. See {@link <a href="#purchasesconfiguration">PurchasesConfiguration</a>} |
+| Param               | Type                                                                                                            | Description                                                                                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`configuration`** | <code><a href="#purchasesconfigurationwithlayoutdirection">PurchasesConfigurationWithLayoutDirection</a></code> | RevenueCat configuration object including the API key and other optional parameters. See {@link <a href="#purchasesconfiguration">PurchasesConfiguration</a>} |
 
 --------------------
 
@@ -1259,16 +1259,15 @@ Check if configure has finished and Purchases has been configured.
 ### overridePreferredUILocale(...)
 
 ```typescript
-overridePreferredUILocale(options: { locale: string | null; }) => Promise<void>
+overridePreferredUILocale(options: { locale: string | null; honorLayoutDirection?: boolean; }) => Promise<void>
 ```
 
-Override the preferred UI locale for RevenueCat UI components at runtime. This affects both API requests
-and UI rendering. If the locale changes, this will automatically clear the offerings cache and trigger
-a background refetch to get paywall templates with the correct localizations.
+Override the preferred UI locale for RevenueCat UI components at runtime.
+If honorLayoutDirection is true, RevenueCat UI components will also derive layout direction from this locale.
 
-| Param         | Type                                     | Description                                                               |
-| ------------- | ---------------------------------------- | ------------------------------------------------------------------------- |
-| **`options`** | <code>{ locale: string \| null; }</code> | The locale string (e.g., "es-ES", "en-US") or null to use system default. |
+| Param         | Type                                                                     | Description                                                               |
+| ------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| **`options`** | <code>{ locale: string \| null; honorLayoutDirection?: boolean; }</code> | The locale string (e.g., "es-ES", "en-US") or null to use system default. |
 
 --------------------
 
@@ -1402,11 +1401,11 @@ The EntitlementInfo object gives you access to all of the information about the 
 
 Represents a non-subscription transaction in the <a href="#store">Store</a>.
 
-| Prop                        | Type                        | Description                                          |
-| --------------------------- | --------------------------- | ---------------------------------------------------- |
-| **`transactionIdentifier`** | <code>string</code>         | Id of the transaction.                               |
-| **`productIdentifier`**     | <code>string</code>         | Product Id associated with the transaction.          |
-| **`purchaseDate`**          | <code>string</code>         | Purchase date of the transaction in ISO 8601 format. |
+| Prop                        | Type                | Description                                          |
+| --------------------------- | ------------------- | ---------------------------------------------------- |
+| **`transactionIdentifier`** | <code>string</code> | Id of the transaction.                               |
+| **`productIdentifier`**     | <code>string</code> | Product Id associated with the transaction.          |
+| **`purchaseDate`**          | <code>string</code> | Purchase date of the transaction in ISO 8601 format. |
 | **`purchaseToken`**         | <code>string \| null</code> | Purchase token of the transaction. Android only.     |
 
 
@@ -1818,6 +1817,11 @@ Options for tracking a custom paywall impression.
 
 
 ### Type Aliases
+
+
+#### PurchasesConfigurationWithLayoutDirection
+
+<code><a href="#purchasesconfiguration">PurchasesConfiguration</a> & { /** * Whether RevenueCat UI components should also derive layout direction from * preferredUILocaleOverride. Defaults to false. */ preferredUILocaleOverrideHonorsLayoutDirection?: boolean; }</code>
 
 
 #### PurchasesAreCompletedBy

--- a/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
+++ b/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
@@ -109,6 +109,8 @@ class PurchasesPlugin : Plugin() {
         val diagnosticsEnabled = call.getBoolean("diagnosticsEnabled")
         val automaticDeviceIdentifierCollectionEnabled = call.getBoolean("automaticDeviceIdentifierCollectionEnabled")
         val preferredLocale = call.getString("preferredUILocaleOverride")
+        val preferredLocaleHonorsLayoutDirection =
+            call.getBoolean("preferredUILocaleOverrideHonorsLayoutDirection", false)
 
         configure(
             context.applicationContext,
@@ -124,6 +126,9 @@ class PurchasesPlugin : Plugin() {
             automaticDeviceIdentifierCollectionEnabled = automaticDeviceIdentifierCollectionEnabled,
             preferredLocale = preferredLocale,
         )
+        if (preferredLocaleHonorsLayoutDirection == true) {
+            overridePreferredLocale(preferredLocale, honorLayoutDirection = true)
+        }
         Purchases.sharedInstance.updatedCustomerInfoListener = UpdatedCustomerInfoListener { customerInfo ->
             customerInfo.mapAsync { map ->
                 for (callbackId in customerInfoListeners) {
@@ -703,8 +708,24 @@ class PurchasesPlugin : Plugin() {
     fun overridePreferredUILocale(call: PluginCall) {
         if (rejectIfNotConfigured(call)) return
         val locale = call.getString("locale")
-        overridePreferredLocaleCommon(locale)
+        val honorLayoutDirection = call.getBoolean("honorLayoutDirection", false) == true
+        overridePreferredLocale(locale, honorLayoutDirection)
         call.resolve()
+    }
+
+    private fun overridePreferredLocale(locale: String?, honorLayoutDirection: Boolean) {
+        if (!honorLayoutDirection) {
+            overridePreferredLocaleCommon(locale)
+            return
+        }
+
+        runCatching {
+            Purchases::class.java
+                .getMethod("overridePreferredUILocale", String::class.java, java.lang.Boolean.TYPE)
+                .invoke(Purchases.sharedInstance, locale, true)
+        }.getOrElse {
+            overridePreferredLocaleCommon(locale)
+        }
     }
 
     @PluginMethod(returnType = PluginMethod.RETURN_NONE)

--- a/api-report/purchases-capacitor.api.md
+++ b/api-report/purchases-capacitor.api.md
@@ -91,6 +91,11 @@ export const Purchases: PurchasesPlugin;
 // @public (undocumented)
 export type PurchasesCallbackId = string;
 
+// @public
+export type PurchasesConfigurationWithLayoutDirection = PurchasesConfiguration & {
+    preferredUILocaleOverrideHonorsLayoutDirection?: boolean;
+};
+
 // @public (undocumented)
 export interface PurchasesPlugin {
     addCustomerInfoUpdateListener(customerInfoUpdateListener: CustomerInfoUpdateListener): Promise<PurchasesCallbackId>;
@@ -118,7 +123,7 @@ export interface PurchasesPlugin {
         [productId: string]: IntroEligibility;
     }>;
     collectDeviceIdentifiers(): Promise<void>;
-    configure(configuration: PurchasesConfiguration): Promise<void>;
+    configure(configuration: PurchasesConfigurationWithLayoutDirection): Promise<void>;
     enableAdServicesAttributionTokenCollection(): Promise<void>;
     getAppUserID(): Promise<{
         appUserID: string;
@@ -163,6 +168,7 @@ export interface PurchasesPlugin {
         customerInfo: CustomerInfo;
     }>;
     overridePreferredUILocale(options: {
+        honorLayoutDirection?: boolean;
         locale: string | null;
     }): Promise<void>;
     parseAsWebPurchaseRedemption(options: {

--- a/api-report/purchases-capacitor.api.md
+++ b/api-report/purchases-capacitor.api.md
@@ -91,7 +91,7 @@ export const Purchases: PurchasesPlugin;
 // @public (undocumented)
 export type PurchasesCallbackId = string;
 
-// @public
+// @public (undocumented)
 export type PurchasesConfigurationWithLayoutDirection = PurchasesConfiguration & {
     preferredUILocaleOverrideHonorsLayoutDirection?: boolean;
 };
@@ -168,8 +168,8 @@ export interface PurchasesPlugin {
         customerInfo: CustomerInfo;
     }>;
     overridePreferredUILocale(options: {
-        honorLayoutDirection?: boolean;
         locale: string | null;
+        honorLayoutDirection?: boolean;
     }): Promise<void>;
     parseAsWebPurchaseRedemption(options: {
         urlString: string;

--- a/apitesters/src/purchases.ts
+++ b/apitesters/src/purchases.ts
@@ -389,6 +389,7 @@ function checkShouldPurchasePromoProductListener() {
 
 async function checkLocaleAndPaywallImpression(plugin: PurchasesPlugin) {
   await plugin.overridePreferredUILocale({ locale: 'en-US' });
+  await plugin.overridePreferredUILocale({ locale: 'ar-SA', honorLayoutDirection: true });
   await plugin.overridePreferredUILocale({ locale: null });
 }
 

--- a/ios/Sources/RevenuecatPurchasesCapacitor/PurchasesPlugin.swift
+++ b/ios/Sources/RevenuecatPurchasesCapacitor/PurchasesPlugin.swift
@@ -1,6 +1,7 @@
 // swiftlint:disable file_length type_body_length
 
 import Foundation
+import ObjectiveC
 import Capacitor
 import PurchasesHybridCommon
 import RevenueCat
@@ -133,6 +134,8 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate, CAPBridgedPlugin {
         let diagnosticsEnabled = call.getBool("diagnosticsEnabled") ?? false
         let automaticDeviceIdentifierCollectionEnabled = call.getBool("automaticDeviceIdentifierCollectionEnabled") ?? true
         let preferredLocale = call.getString("preferredUILocaleOverride")
+        let preferredLocaleHonorsLayoutDirection =
+            call.getBool("preferredUILocaleOverrideHonorsLayoutDirection") ?? false
 
         let purchases = Purchases.configure(apiKey: apiKey,
                                             appUserID: appUserID,
@@ -148,6 +151,9 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate, CAPBridgedPlugin {
                                             automaticDeviceIdentifierCollectionEnabled: automaticDeviceIdentifierCollectionEnabled,
                                             preferredLocale: preferredLocale)
         purchases.delegate = self
+        if preferredLocaleHonorsLayoutDirection {
+            self.overridePreferredLocale(preferredLocale, honorLayoutDirection: true)
+        }
         call.resolve()
     }
 
@@ -671,8 +677,29 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate, CAPBridgedPlugin {
     @objc func overridePreferredUILocale(_ call: CAPPluginCall) {
         guard self.rejectIfPurchasesNotConfigured(call) else { return }
         let locale = call.getString("locale")
-        CommonFunctionality.overridePreferredLocale(locale)
+        let honorLayoutDirection = call.getBool("honorLayoutDirection") ?? false
+        self.overridePreferredLocale(locale, honorLayoutDirection: honorLayoutDirection)
         call.resolve()
+    }
+
+    private func overridePreferredLocale(_ locale: String?, honorLayoutDirection: Bool) {
+        guard honorLayoutDirection else {
+            CommonFunctionality.overridePreferredLocale(locale)
+            return
+        }
+
+        let selector = NSSelectorFromString("overridePreferredUILocale:honorLayoutDirection:")
+        let purchases = Purchases.shared
+        guard purchases.responds(to: selector),
+              let method = class_getInstanceMethod(type(of: purchases), selector) else {
+            CommonFunctionality.overridePreferredLocale(locale)
+            return
+        }
+
+        typealias OverridePreferredLocaleImp = @convention(c) (AnyObject, Selector, NSString?, Bool) -> Void
+        let implementation = method_getImplementation(method)
+        let function = unsafeBitCast(implementation, to: OverridePreferredLocaleImp.self)
+        function(purchases, selector, locale as NSString?, honorLayoutDirection)
     }
 
     @objc func trackCustomPaywallImpression(_ call: CAPPluginCall) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -32,6 +32,14 @@ export * from '@revenuecat/purchases-typescript-internal-esm';
 
 export type PurchasesCallbackId = string;
 
+export type PurchasesConfigurationWithLayoutDirection = PurchasesConfiguration & {
+  /**
+   * Whether RevenueCat UI components should also derive layout direction from
+   * preferredUILocaleOverride. Defaults to false.
+   */
+  preferredUILocaleOverrideHonorsLayoutDirection?: boolean;
+};
+
 export interface GetProductOptions {
   /**
    * Array of product identifiers to obtain
@@ -199,7 +207,7 @@ export interface PurchasesPlugin {
    * Sets up Purchases with your API key and an app user id.
    * @param {PurchasesConfiguration} configuration RevenueCat configuration object including the API key and other optional parameters. See {@link PurchasesConfiguration}
    */
-  configure(configuration: PurchasesConfiguration): Promise<void>;
+  configure(configuration: PurchasesConfigurationWithLayoutDirection): Promise<void>;
 
   /**
    * Fetches the virtual currencies for the current subscriber.
@@ -907,14 +915,13 @@ export interface PurchasesPlugin {
   isConfigured(): Promise<{ isConfigured: boolean }>;
 
   /**
-   * Override the preferred UI locale for RevenueCat UI components at runtime. This affects both API requests
-   * and UI rendering. If the locale changes, this will automatically clear the offerings cache and trigger
-   * a background refetch to get paywall templates with the correct localizations.
+   * Override the preferred UI locale for RevenueCat UI components at runtime.
+   * If honorLayoutDirection is true, RevenueCat UI components will also derive layout direction from this locale.
    *
    * @param options The locale string (e.g., "es-ES", "en-US") or null to use system default.
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet.
    */
-  overridePreferredUILocale(options: { locale: string | null }): Promise<void>;
+  overridePreferredUILocale(options: { locale: string | null; honorLayoutDirection?: boolean }): Promise<void>;
 
   /**
    * Tracks an impression of a custom paywall. Use this to record when a user views your custom paywall

--- a/src/web.ts
+++ b/src/web.ts
@@ -11,7 +11,6 @@ import type {
   LogHandler,
   LogInResult,
   MakePurchaseResult,
-  PurchasesConfiguration,
   PurchasesEntitlementInfo,
   PurchasesOffering,
   PurchasesOfferings,
@@ -41,6 +40,7 @@ import type {
   PurchasePackageOptions,
   PurchasePackageWithWinBackOfferOptions,
   PurchaseProductWithWinBackOfferOptions,
+  PurchasesConfigurationWithLayoutDirection,
   PurchasesPlugin,
   PurchaseStoreProductOptions,
   PurchaseSubscriptionOptionOptions,
@@ -53,7 +53,7 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
   private shouldMockWebResults = false;
   private webNotSupportedErrorMessage = 'Web not supported in this plugin.';
 
-  configure(_configuration: PurchasesConfiguration): Promise<void> {
+  configure(_configuration: PurchasesConfigurationWithLayoutDirection): Promise<void> {
     return this.mockNonReturningFunctionIfEnabled('configure');
   }
 
@@ -352,7 +352,7 @@ export class PurchasesWeb extends WebPlugin implements PurchasesPlugin {
     return this.mockReturningFunctionIfEnabled('isConfigured', mockResult);
   }
 
-  overridePreferredUILocale(_options: { locale: string | null }): Promise<void> {
+  overridePreferredUILocale(_options: { locale: string | null; honorLayoutDirection?: boolean }): Promise<void> {
     return this.mockNonReturningFunctionIfEnabled('overridePreferredUILocale');
   }
 


### PR DESCRIPTION
## Summary
- add preferredUILocaleOverrideHonorsLayoutDirection to Capacitor configuration, defaulting false
- add honorLayoutDirection to overridePreferredUILocale runtime API, defaulting false
- bridge the flag to native SDKs with backward-compatible fallbacks
- update API report, README docs, API tester usage, and changelog entry

## Tests
- npm run eslint

## Notes
- npm run build && npm run extract-api is currently blocked by an existing src/web.ts purchaseToken type error.
- npx tsc -p apitesters is also blocked by existing apitester package-resolution/enum return issues.