### PR TITLE
Remove unused install-sdkman command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,21 +103,6 @@ commands:
             - purchases-capacitor-ui/node_modules
           key: v2-mac-ui-dependencies-{{ checksum "purchases-capacitor-ui/package.json" }}
 
-  install-sdkman:
-    description: Install SDKMAN
-    steps:
-      - run:
-          name: Installing SDKMAN
-          command: |
-            curl -s "https://get.sdkman.io?rcupdate=false" | bash
-            echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
-            source $BASH_ENV
-      - run:
-          name: Setup Java environment
-          command: |
-            sdk env install
-            echo -e '\nexport JAVA_HOME="/home/circleci/.sdkman/candidates/java/current"' >> $BASH_ENV
-
   copy-npm-rc:
     steps:
       - run:


### PR DESCRIPTION
The local `install-sdkman` command is defined but never invoked anywhere in the repo. Removing it eliminates a footgun: the implementation uses unauthenticated `curl https://get.sdkman.io | bash`, so any future caller would inherit that. If a future job needs SDKMAN, it should adopt the SHA-pinned `revenuecat/install-sdkman` orb command added in [sdks-circleci-orb#55](https://github.com/RevenueCat/sdks-circleci-orb/pull/55).

The orb pin (currently `3.16.0`) is intentionally not bumped here — that can land separately.