### PR TITLE
Add presentedOfferingContext support to custom paywall impression events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1828,9 +1828,9 @@ Options for tracking a custom paywall impression.
 
 | Prop             | Type                                                            | Description                                                                                                                                                              |
 | ---------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **`paywallId`**  | <code>string</code>                                             | The identifier of the paywall that was shown.                                                                                                                            |
+| **`paywallId`**  | <code>string \| null</code>                                     | The identifier of the paywall that was shown.                                                                                                                            |
 | **`offering`**   | <code><a href="#purchasesoffering">PurchasesOffering</a></code> | The offering associated with the custom paywall. Pass the offering object so RevenueCat can track placement and targeting context for placement-resolved offerings.      |
-| **`offeringId`** | <code>string</code>                                             | Deprecated. An optional identifier for the offering associated with the custom paywall. Pass `offering` instead so RevenueCat can track placement and targeting context. |
+| **`offeringId`** | <code>string \| null</code>                                     | Deprecated. An optional identifier for the offering associated with the custom paywall. Pass `offering` instead so RevenueCat can track placement and targeting context. |
 
 
 ### Type Aliases

--- a/README.md
+++ b/README.md
@@ -1285,9 +1285,9 @@ so that RevenueCat can track paywall analytics.
 Call this method once per paywall display, ideally when the paywall first becomes visible to the user,
 not in callbacks that may fire multiple times for the same display.
 
-| Param         | Type                                                                                                | Description                                                                                      |
-| ------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| **`options`** | <code><a href="#trackcustompaywallimpressionoptions">TrackCustomPaywallImpressionOptions</a></code> | Optional parameters for the impression. Include `paywallId` to identify which paywall was shown. |
+| Param         | Type                                                                                                | Description                                                                                                                                                                                |
+| ------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`options`** | <code><a href="#trackcustompaywallimpressionoptions">TrackCustomPaywallImpressionOptions</a></code> | Optional parameters for the impression. Include `paywallId` to identify which paywall was shown, and pass `offering` when available so the SDK can derive placement and targeting context. |
 
 --------------------
 
@@ -1826,10 +1826,11 @@ Holds the information about a Win-Back Offer in Apple's App <a href="#store">Sto
 
 Options for tracking a custom paywall impression.
 
-| Prop             | Type                        | Description                                                                                                                                                   |
-| ---------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`paywallId`**  | <code>string \| null</code> | The identifier of the paywall that was shown.                                                                                                                 |
-| **`offeringId`** | <code>string \| null</code> | An optional identifier for the offering associated with the custom paywall. If not provided, the SDK will use the current offering identifier from the cache. |
+| Prop             | Type                                                            | Description                                                                                                                                                              |
+| ---------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`paywallId`**  | <code>string</code>                                             | The identifier of the paywall that was shown.                                                                                                                            |
+| **`offering`**   | <code><a href="#purchasesoffering">PurchasesOffering</a></code> | The offering associated with the custom paywall. Pass the offering object so RevenueCat can track placement and targeting context for placement-resolved offerings.      |
+| **`offeringId`** | <code>string</code>                                             | Deprecated. An optional identifier for the offering associated with the custom paywall. Pass `offering` instead so RevenueCat can track placement and targeting context. |
 
 
 ### Type Aliases

--- a/README.md
+++ b/README.md
@@ -1826,11 +1826,11 @@ Holds the information about a Win-Back Offer in Apple's App <a href="#store">Sto
 
 Options for tracking a custom paywall impression.
 
-| Prop             | Type                                                            | Description                                                                                                                                                              |
-| ---------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **`paywallId`**  | <code>string \| null</code>                                     | The identifier of the paywall that was shown.                                                                                                                            |
-| **`offering`**   | <code><a href="#purchasesoffering">PurchasesOffering</a></code> | The offering associated with the custom paywall. Pass the offering object so RevenueCat can track placement and targeting context for placement-resolved offerings.      |
-| **`offeringId`** | <code>string \| null</code>                                     | Deprecated. An optional identifier for the offering associated with the custom paywall. Pass `offering` instead so RevenueCat can track placement and targeting context. |
+| Prop             | Type                                                                    | Description                                                                                                                                                              |
+| ---------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`paywallId`**  | <code>string \| null</code>                                             | The identifier of the paywall that was shown.                                                                                                                            |
+| **`offering`**   | <code><a href="#purchasesoffering">PurchasesOffering</a> \| null</code> | The offering associated with the custom paywall. Pass the offering object so RevenueCat can track placement and targeting context for placement-resolved offerings.      |
+| **`offeringId`** | <code>string \| null</code>                                             | Deprecated. Pass `offering` instead so RevenueCat can track placement and targeting context. An optional identifier for the offering associated with the custom paywall. |
 
 
 ### Type Aliases

--- a/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
+++ b/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
@@ -27,6 +27,7 @@ import com.revenuecat.purchases.hybridcommon.purchaseProduct
 import com.revenuecat.purchases.hybridcommon.showInAppMessagesIfNeeded
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.InAppMessageType
+import org.json.JSONArray
 import org.json.JSONObject
 import com.revenuecat.purchases.hybridcommon.canMakePayments as canMakePaymentsCommon
 import com.revenuecat.purchases.hybridcommon.checkTrialOrIntroductoryPriceEligibility as checkTrialOrIntroductoryPriceEligibilityCommon
@@ -713,7 +714,7 @@ class PurchasesPlugin : Plugin() {
     @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun trackCustomPaywallImpression(call: PluginCall) {
         if (rejectIfNotConfigured(call)) return
-        trackCustomPaywallImpressionCommon(call.data.convertToMap())
+        trackCustomPaywallImpressionCommon(mapWithoutNullValues(call.data))
         call.resolve()
     }
 
@@ -723,6 +724,36 @@ class PurchasesPlugin : Plugin() {
 
     private val activity: Activity
         get() = bridge.activity
+
+    private fun mapWithoutNullValues(jsonObject: JSONObject): Map<String, Any> {
+        return jsonObject.keys().asSequence<String>().mapNotNull { key ->
+            valueWithoutNullValues(jsonObject.opt(key))?.let { key to it }
+        }.toMap()
+    }
+
+    private fun mapWithoutNullValues(map: Map<String, Any?>): Map<String, Any> {
+        return map.mapNotNull { (key, value) ->
+            valueWithoutNullValues(value)?.let { key to it }
+        }.toMap()
+    }
+
+    private fun valueWithoutNullValues(value: Any?): Any? {
+        return when (value) {
+            null, JSONObject.NULL -> null
+            is JSONObject -> mapWithoutNullValues(value)
+            is JSONArray -> (0 until value.length()).mapNotNull { index ->
+                valueWithoutNullValues(value.opt(index))
+            }
+            is Map<*, *> -> value.mapNotNull { (key, entryValue) ->
+                val filteredValue = valueWithoutNullValues(entryValue)
+                if (key is String && filteredValue != null) key to filteredValue else null
+            }.toMap()
+            is List<*> -> value.mapNotNull { item ->
+                valueWithoutNullValues(item)
+            }
+            else -> value
+        }
+    }
 
     private fun getOnResult(call: PluginCall, wrapperKey: String? = null): OnResult {
         return object : OnResult {

--- a/api-report/purchases-capacitor.api.md
+++ b/api-report/purchases-capacitor.api.md
@@ -316,8 +316,10 @@ export type SyncObserverModeAmazonPurchaseOptions = SyncAmazonPurchaseOptions;
 
 // @public
 export interface TrackCustomPaywallImpressionOptions {
-    offeringId?: string | null;
-    paywallId?: string | null;
+    offering?: PurchasesOffering;
+    // @deprecated
+    offeringId?: string;
+    paywallId?: string;
 }
 
 

--- a/api-report/purchases-capacitor.api.md
+++ b/api-report/purchases-capacitor.api.md
@@ -316,10 +316,10 @@ export type SyncObserverModeAmazonPurchaseOptions = SyncAmazonPurchaseOptions;
 
 // @public
 export interface TrackCustomPaywallImpressionOptions {
-    offering?: PurchasesOffering;
+    offering?: PurchasesOffering | null;
     // @deprecated
-    offeringId?: string;
-    paywallId?: string;
+    offeringId?: string | null;
+    paywallId?: string | null;
 }
 
 

--- a/apitesters/src/purchases.ts
+++ b/apitesters/src/purchases.ts
@@ -406,7 +406,7 @@ async function checkTrackCustomPaywallImpression(plugin: PurchasesPlugin) {
     paywallId: 'my-paywall',
     offeringId: 'my-offering',
   });
-  await plugin.trackCustomPaywallImpression({ paywallId: null, offeringId: null });
+  await plugin.trackCustomPaywallImpression({ paywallId: null, offering: null, offeringId: null });
 }
 
 function checkTrackCustomPaywallImpressionOptions() {
@@ -418,5 +418,5 @@ function checkTrackCustomPaywallImpressionOptions() {
     offering: {} as PurchasesOffering,
   };
   const options5: TrackCustomPaywallImpressionOptions = { offeringId: 'my-offering' };
-  const options6: TrackCustomPaywallImpressionOptions = { paywallId: null, offeringId: null };
+  const options6: TrackCustomPaywallImpressionOptions = { paywallId: null, offering: null, offeringId: null };
 }

--- a/apitesters/src/purchases.ts
+++ b/apitesters/src/purchases.ts
@@ -406,6 +406,7 @@ async function checkTrackCustomPaywallImpression(plugin: PurchasesPlugin) {
     paywallId: 'my-paywall',
     offeringId: 'my-offering',
   });
+  await plugin.trackCustomPaywallImpression({ paywallId: null, offeringId: null });
 }
 
 function checkTrackCustomPaywallImpressionOptions() {
@@ -417,4 +418,5 @@ function checkTrackCustomPaywallImpressionOptions() {
     offering: {} as PurchasesOffering,
   };
   const options5: TrackCustomPaywallImpressionOptions = { offeringId: 'my-offering' };
+  const options6: TrackCustomPaywallImpressionOptions = { paywallId: null, offeringId: null };
 }

--- a/apitesters/src/purchases.ts
+++ b/apitesters/src/purchases.ts
@@ -397,19 +397,24 @@ async function checkTrackCustomPaywallImpression(plugin: PurchasesPlugin) {
   await plugin.trackCustomPaywallImpression({});
   await plugin.trackCustomPaywallImpression({ paywallId: 'my-paywall' });
   await plugin.trackCustomPaywallImpression({ offeringId: 'my-offering' });
+  await plugin.trackCustomPaywallImpression({ offering: {} as PurchasesOffering });
+  await plugin.trackCustomPaywallImpression({
+    paywallId: 'my-paywall',
+    offering: {} as PurchasesOffering,
+  });
   await plugin.trackCustomPaywallImpression({
     paywallId: 'my-paywall',
     offeringId: 'my-offering',
   });
-  await plugin.trackCustomPaywallImpression({ paywallId: null, offeringId: null });
 }
 
 function checkTrackCustomPaywallImpressionOptions() {
   const options1: TrackCustomPaywallImpressionOptions = {};
   const options2: TrackCustomPaywallImpressionOptions = { paywallId: 'my-paywall' };
-  const options3: TrackCustomPaywallImpressionOptions = { offeringId: 'my-offering' };
+  const options3: TrackCustomPaywallImpressionOptions = { offering: {} as PurchasesOffering };
   const options4: TrackCustomPaywallImpressionOptions = {
     paywallId: 'my-paywall',
-    offeringId: 'my-offering',
+    offering: {} as PurchasesOffering,
   };
+  const options5: TrackCustomPaywallImpressionOptions = { offeringId: 'my-offering' };
 }

--- a/example/purchase-tester/src/App.tsx
+++ b/example/purchase-tester/src/App.tsx
@@ -1,6 +1,7 @@
 import { IonApp, IonRouterOutlet, setupIonicReact } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
-import { Route } from 'react-router-dom';
+import type { ComponentType } from 'react';
+import { Route, type RouteProps } from 'react-router-dom';
 import CustomPaywallImpressionTestingScreen from './pages/CustomPaywallImpressionTestingScreen';
 import Home from './pages/Home';
 
@@ -25,12 +26,14 @@ import './theme/variables.css';
 
 setupIonicReact();
 
+const RouterRoute = Route as unknown as ComponentType<RouteProps>;
+
 const App: React.FC = () => (
   <IonApp>
     <IonReactRouter>
       <IonRouterOutlet>
-        <Route exact path="/" component={Home} />
-        <Route exact path="/custom-paywall-impression" component={CustomPaywallImpressionTestingScreen} />
+        <RouterRoute exact path="/" component={Home} />
+        <RouterRoute exact path="/custom-paywall-impression" component={CustomPaywallImpressionTestingScreen} />
       </IonRouterOutlet>
     </IonReactRouter>
   </IonApp>

--- a/example/purchase-tester/src/App.tsx
+++ b/example/purchase-tester/src/App.tsx
@@ -1,4 +1,7 @@
-import { IonApp, setupIonicReact } from '@ionic/react';
+import { IonApp, IonRouterOutlet, setupIonicReact } from '@ionic/react';
+import { IonReactRouter } from '@ionic/react-router';
+import { Route } from 'react-router-dom';
+import CustomPaywallImpressionTestingScreen from './pages/CustomPaywallImpressionTestingScreen';
 import Home from './pages/Home';
 
 /* Core CSS required for Ionic components to work properly */
@@ -24,7 +27,12 @@ setupIonicReact();
 
 const App: React.FC = () => (
   <IonApp>
-    <Home />
+    <IonReactRouter>
+      <IonRouterOutlet>
+        <Route exact path="/" component={Home} />
+        <Route exact path="/custom-paywall-impression" component={CustomPaywallImpressionTestingScreen} />
+      </IonRouterOutlet>
+    </IonReactRouter>
   </IonApp>
 );
 

--- a/example/purchase-tester/src/components/FunctionTesterContainer.tsx
+++ b/example/purchase-tester/src/components/FunctionTesterContainer.tsx
@@ -792,18 +792,6 @@ const FunctionTesterContainer: React.FC<ContainerProps> = () => {
     updateLastFunction('getCachedVirtualCurrencies', cachedVirtualCurrencies);
   };
 
-  const trackCustomPaywallImpression = async () => {
-    const paywallId = window.prompt('Paywall ID (leave empty for none)')?.trim() || undefined;
-    const offeringId = window.prompt('Offering ID (leave empty for none)')?.trim() || undefined;
-
-    if (!paywallId && !offeringId) {
-      await Purchases.trackCustomPaywallImpression();
-    } else {
-      await Purchases.trackCustomPaywallImpression({ paywallId, offeringId });
-    }
-    updateLastFunctionWithoutContent(`trackCustomPaywallImpression (paywallId: ${paywallId ?? 'nil'}, offeringId: ${offeringId ?? 'nil'})`);
-  };
-
   const purchaseProductForWinBackTesting = async () => {
     try {
       const products = await Purchases.getProducts({
@@ -1462,8 +1450,8 @@ const FunctionTesterContainer: React.FC<ContainerProps> = () => {
         <IonButton size="small" onClick={getCachedVirtualCurrencies}>
           Get cached virtual currencies
         </IonButton>
-        <IonButton size="small" onClick={trackCustomPaywallImpression}>
-          Track Custom Paywall Impression
+        <IonButton size="small" routerLink="/custom-paywall-impression">
+          Custom Paywall Impression Testing
         </IonButton>
         <IonButton size="small" onClick={purchaseProductForWinBackTesting}>
           Purchase Product for WinBack Testing

--- a/example/purchase-tester/src/pages/CustomPaywallImpressionTestingScreen.tsx
+++ b/example/purchase-tester/src/pages/CustomPaywallImpressionTestingScreen.tsx
@@ -1,0 +1,202 @@
+import {
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonCard,
+  IonCardContent,
+  IonContent,
+  IonHeader,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonLoading,
+  IonPage,
+  IonText,
+  IonTitle,
+  IonToolbar,
+  useIonAlert,
+  useIonActionSheet,
+} from '@ionic/react';
+import React, { useEffect, useState } from 'react';
+import { Purchases } from '@revenuecat/purchases-capacitor';
+import type { PurchasesOffering } from '@revenuecat/purchases-capacitor';
+
+const CustomPaywallImpressionTestingScreen: React.FC = () => {
+  const [paywallId, setPaywallId] = useState('');
+  const [currentOfferingId, setCurrentOfferingId] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [presentAlert] = useIonAlert();
+  const [presentActionSheet] = useIonActionSheet();
+
+  useEffect(() => {
+    void loadOfferings();
+  }, []);
+
+  const trimmedPaywallId = () => {
+    const trimmedValue = paywallId.trim();
+    return trimmedValue.length > 0 ? trimmedValue : undefined;
+  };
+
+  const loadOfferings = async () => {
+    const offerings = await Purchases.getOfferings();
+    setCurrentOfferingId(offerings.current?.identifier ?? null);
+    return offerings;
+  };
+
+  const trackImpressionWithoutOffering = async () => {
+    setLoading(true);
+    setStatus(null);
+    setError(null);
+
+    try {
+      const offerings = await loadOfferings();
+      const currentOffering = offerings.current;
+      const currentPaywallId = trimmedPaywallId();
+
+      if (!currentOffering) {
+        setStatus('No current offering configured. The native SDK cannot infer an offering for this call.');
+        await presentAlert({
+          header: 'No current offering configured',
+          message:
+            'The native SDK can only infer an offering when getOfferings().current is non-null. Use Track with Offering for this project.',
+          buttons: ['OK'],
+        });
+        return;
+      }
+
+      if (currentPaywallId) {
+        await Purchases.trackCustomPaywallImpression({ paywallId: currentPaywallId });
+      } else {
+        await Purchases.trackCustomPaywallImpression();
+      }
+
+      setStatus(
+        `Tracked without offering (paywallId: ${currentPaywallId ?? 'nil'}, current offering: ${currentOffering.identifier})`,
+      );
+    } catch (e) {
+      setError(`${e}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const trackImpressionWithOffering = async (offering: PurchasesOffering) => {
+    setLoading(true);
+    setStatus(null);
+    setError(null);
+
+    try {
+      const currentPaywallId = trimmedPaywallId();
+
+      await Purchases.trackCustomPaywallImpression({
+        paywallId: currentPaywallId,
+        offering,
+      });
+
+      setStatus(`Tracked with offering: ${offering.identifier} (paywallId: ${currentPaywallId ?? 'nil'})`);
+    } catch (e) {
+      setError(`${e}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const showOfferingPicker = async () => {
+    setLoading(true);
+    setStatus('Loading offerings...');
+    setError(null);
+
+    try {
+      const offerings = await loadOfferings();
+      const offeringOptions = Object.values(offerings.all).sort((a, b) => a.identifier.localeCompare(b.identifier));
+
+      setLoading(false);
+
+      if (offeringOptions.length === 0) {
+        setStatus('No offerings available');
+        return;
+      }
+
+      await presentActionSheet({
+        header: 'Select Offering',
+        buttons: [
+          ...offeringOptions.map((offering) => ({
+            text: offering.identifier,
+            handler: () => {
+              void trackImpressionWithOffering(offering);
+            },
+          })),
+          {
+            text: 'Cancel',
+            role: 'cancel',
+            handler: () => {
+              setStatus(null);
+            },
+          },
+        ],
+      });
+    } catch (e) {
+      setError(`${e}`);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/" />
+          </IonButtons>
+          <IonTitle>Custom Paywall Impression Testing</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        <div className="ion-padding">
+          <IonText>
+            <h1>Custom Paywall Impression</h1>
+            <p>Use this screen to test tracking custom paywall impressions.</p>
+            <p>Current offering: {currentOfferingId ?? 'nil'}</p>
+          </IonText>
+
+          <IonList inset>
+            <IonItem>
+              <IonLabel position="stacked">Paywall ID</IonLabel>
+              <IonInput
+                value={paywallId}
+                placeholder="Optional, leave empty for none"
+                onIonInput={(event) => setPaywallId(event.detail.value ?? '')}
+              />
+            </IonItem>
+          </IonList>
+
+          <IonButton expand="block" disabled={loading} onClick={trackImpressionWithoutOffering}>
+            Track without Offering
+          </IonButton>
+          <IonButton expand="block" disabled={loading} onClick={showOfferingPicker}>
+            Track with Offering
+          </IonButton>
+
+          {status && (
+            <IonCard color="success">
+              <IonCardContent>{status}</IonCardContent>
+            </IonCard>
+          )}
+
+          {error && (
+            <IonCard color="danger">
+              <IonCardContent>Error: {error}</IonCardContent>
+            </IonCard>
+          )}
+        </div>
+
+        <IonLoading isOpen={loading} message="Loading..." />
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default CustomPaywallImpressionTestingScreen;

--- a/ios/Sources/RevenuecatPurchasesCapacitor/PurchasesPlugin.swift
+++ b/ios/Sources/RevenuecatPurchasesCapacitor/PurchasesPlugin.swift
@@ -677,7 +677,8 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate, CAPBridgedPlugin {
 
     @objc func trackCustomPaywallImpression(_ call: CAPPluginCall) {
         guard self.rejectIfPurchasesNotConfigured(call) else { return }
-        CommonFunctionality.trackCustomPaywallImpression(call.options as? [String: Any] ?? [:])
+        let data = (call.options as? [String: Any] ?? [:]).mappingNSNullToNil()
+        CommonFunctionality.trackCustomPaywallImpression(data)
         call.resolve()
     }
 
@@ -686,5 +687,25 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate, CAPBridgedPlugin {
             self?.bridge?.savedCall(withID: callbackId)?.resolve(CommonFunctionality.encode(customerInfo: customerInfo))
         }
         self.lastReceivedCustomerInfo = customerInfo
+    }
+
+}
+
+private extension Dictionary where Key == String, Value == Any {
+    func mappingNSNullToNil() -> [String: Any] {
+        compactMapValues { valueByMappingNSNullToNil($0) }
+    }
+}
+
+private func valueByMappingNSNullToNil(_ value: Any) -> Any? {
+    switch value {
+    case is NSNull:
+        return nil
+    case let dictionary as [String: Any]:
+        return dictionary.mappingNSNullToNil()
+    case let array as [Any]:
+        return array.compactMap { valueByMappingNSNullToNil($0) }
+    default:
+        return value
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -948,7 +948,8 @@ export interface PurchasesPlugin {
    * Call this method once per paywall display, ideally when the paywall first becomes visible to the user,
    * not in callbacks that may fire multiple times for the same display.
    *
-   * @param options Optional parameters for the impression. Include `paywallId` to identify which paywall was shown.
+   * @param options Optional parameters for the impression. Include `paywallId` to identify which paywall was shown,
+   * and pass `offering` when available so the SDK can derive placement and targeting context.
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet.
    */
   trackCustomPaywallImpression(options?: TrackCustomPaywallImpressionOptions): Promise<void>;
@@ -959,10 +960,21 @@ export interface PurchasesPlugin {
  */
 export interface TrackCustomPaywallImpressionOptions {
   /** The identifier of the paywall that was shown. */
-  paywallId?: string | null;
+  paywallId?: string;
   /**
-   * An optional identifier for the offering associated with the custom paywall.
-   * If not provided, the SDK will use the current offering identifier from the cache.
+   * The offering associated with the custom paywall.
+   *
+   * Pass the offering object so RevenueCat can track placement and targeting
+   * context for placement-resolved offerings.
    */
-  offeringId?: string | null;
+  offering?: PurchasesOffering;
+  /**
+   * Deprecated. An optional identifier for the offering associated with the custom paywall.
+   *
+   * Pass `offering` instead so RevenueCat can track placement and
+   * targeting context.
+   *
+   * @deprecated Use `offering` instead.
+   */
+  offeringId?: string;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -960,7 +960,7 @@ export interface PurchasesPlugin {
  */
 export interface TrackCustomPaywallImpressionOptions {
   /** The identifier of the paywall that was shown. */
-  paywallId?: string;
+  paywallId?: string | null;
   /**
    * The offering associated with the custom paywall.
    *
@@ -976,5 +976,5 @@ export interface TrackCustomPaywallImpressionOptions {
    *
    * @deprecated Use `offering` instead.
    */
-  offeringId?: string;
+  offeringId?: string | null;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -967,12 +967,12 @@ export interface TrackCustomPaywallImpressionOptions {
    * Pass the offering object so RevenueCat can track placement and targeting
    * context for placement-resolved offerings.
    */
-  offering?: PurchasesOffering;
+  offering?: PurchasesOffering | null;
   /**
-   * Deprecated. An optional identifier for the offering associated with the custom paywall.
-   *
-   * Pass `offering` instead so RevenueCat can track placement and
+   * Deprecated. Pass `offering` instead so RevenueCat can track placement and
    * targeting context.
+   *
+   * An optional identifier for the offering associated with the custom paywall.
    *
    * @deprecated Use `offering` instead.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,49 @@
 import { registerPlugin } from '@capacitor/core';
 
-import type { PurchasesPlugin } from './definitions';
+import type { PurchasesPlugin, TrackCustomPaywallImpressionOptions } from './definitions';
 
-const Purchases = registerPlugin<PurchasesPlugin>('Purchases', {
+type NativeTrackCustomPaywallImpressionOptions = Omit<TrackCustomPaywallImpressionOptions, 'offering'> & {
+  presentedOfferingContext?: unknown;
+};
+
+const nativePlugin = registerPlugin<PurchasesPlugin>('Purchases', {
   web: () => import('./web').then((m) => new m.PurchasesWeb()),
 });
+
+function getNativeTrackCustomPaywallImpressionOptions(
+  options?: TrackCustomPaywallImpressionOptions,
+): NativeTrackCustomPaywallImpressionOptions {
+  const offering = options?.offering;
+  const nativeOptions: NativeTrackCustomPaywallImpressionOptions = {};
+
+  if (options?.paywallId != null) {
+    nativeOptions.paywallId = options.paywallId;
+  }
+
+  if (offering != null) {
+    nativeOptions.offeringId = offering.identifier;
+    const presentedOfferingContext = offering.availablePackages[0]?.presentedOfferingContext;
+    if (presentedOfferingContext != null) {
+      nativeOptions.presentedOfferingContext = presentedOfferingContext;
+    }
+  } else if (options?.offeringId != null) {
+    nativeOptions.offeringId = options.offeringId;
+  }
+
+  return nativeOptions;
+}
+
+const Purchases = new Proxy(nativePlugin, {
+  get(target, prop, receiver) {
+    if (prop === 'trackCustomPaywallImpression') {
+      return (options?: TrackCustomPaywallImpressionOptions): Promise<void> => {
+        return target.trackCustomPaywallImpression(getNativeTrackCustomPaywallImpressionOptions(options));
+      };
+    }
+
+    return Reflect.get(target, prop, receiver);
+  },
+}) as PurchasesPlugin;
 
 export * from './definitions';
 export { Purchases };


### PR DESCRIPTION
Based on PHC PR https://github.com/RevenueCat/purchases-hybrid-common/pull/1665.

## API

We will now send the `presentedOfferingContext` from the passed `Offering` along with the event. This PR adds the new API variant that takes an `Offering` instead of a plain string `offeringId`. The latter is now deprecated in favor of this new API variant. We will derive the `presentedOfferingContext` from this `Offering` and send it along with the request.

```
await Purchases.trackCustomPaywallImpression({ paywallId: "", offering })
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall analytics payloads and adds a JS Proxy around one plugin method; behavior is backward compatible for `offeringId` but new `offering` usage affects how impressions are attributed.
> 
> **Overview**
> **Custom paywall impression tracking** now accepts a full `PurchasesOffering` (not just `offeringId`), so RevenueCat can attach **placement and targeting context** via `presentedOfferingContext` on impression events. String `offeringId` remains supported but is **deprecated**.
> 
> The TypeScript entry point wraps `trackCustomPaywallImpression` to map `offering` into the native payload (`offeringId` plus `presentedOfferingContext` from the offering’s first package). **iOS and Android** bridges strip null sentinels from plugin call data before forwarding to hybrid common.
> 
> Public types, API report, README, and API tests are updated. The purchase-tester example adds a **dedicated screen** and routing to exercise tracking with and without an offering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb3ba61b4cc52ddda3efd4be7e69e1b4f477eb18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->