### PR TITLE
chore: Add 3-day Dependabot cooldown, excluding fastlane plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
+      exclude:
+        - "fastlane-plugin-revenuecat_internal"


### PR DESCRIPTION
Adds a 3-day cooldown to Dependabot so we don't pick up dependency versions that were released less than 3 days ago. Our own `fastlane-plugin-revenuecat_internal` is excluded from the cooldown so it continues to update immediately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/dependency automation config only; no application runtime or security logic changes.
> 
> **Overview**
> **Dependabot** for the Bundler ecosystem now waits **3 days** after a dependency release before opening update PRs, via a new `cooldown.default-days: 3` block in `.github/dependabot.yml`.
> 
> **`fastlane-plugin-revenuecat_internal`** is listed under `cooldown.exclude` so that package still updates on the existing daily schedule without the delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d0816adb3a1035745cc4c4475f579b15755c159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->