### PR TITLE
fix: pin purchases-capacitor as exact peerDependency in UI package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
           key: v2-unix-ui-dependencies-{{ checksum "purchases-capacitor-ui/package.json" }}
       - run:
           name: Install UI package dependencies
-          command: cd purchases-capacitor-ui && npm install
+          command: cd purchases-capacitor-ui && npm install --legacy-peer-deps
       - save_cache:
           paths:
             - purchases-capacitor-ui/node_modules
@@ -97,7 +97,7 @@ commands:
           key: v2-mac-ui-dependencies-{{ checksum "purchases-capacitor-ui/package.json" }}
       - run:
           name: Install UI package dependencies
-          command: cd purchases-capacitor-ui && npm install
+          command: cd purchases-capacitor-ui && npm install --legacy-peer-deps
       - save_cache:
           paths:
             - purchases-capacitor-ui/node_modules

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,7 @@
 files_with_version_number = {
     './.version' => ['{x}'],
     './package.json' => ['"version": "{x}"'],
-    './purchases-capacitor-ui/package.json' => ['"version": "{x}"'],
+    './purchases-capacitor-ui/package.json' => ['"version": "{x}"', '"@revenuecat/purchases-capacitor": "{x}"'],
     './ios/Sources/RevenuecatPurchasesCapacitor/PurchasesPlugin.swift' => ['platformVersion = "{x}"'],
     './android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt' => ['PLUGIN_VERSION = "{x}"']
 }

--- a/purchases-capacitor-ui/package.json
+++ b/purchases-capacitor-ui/package.json
@@ -65,11 +65,11 @@
   },
   "dependencies": {
     "@capacitor/core": "^8.0.0",
-    "@revenuecat/purchases-capacitor": "^10.2.4",
     "@revenuecat/purchases-typescript-internal-esm": "18.15.1"
   },
   "peerDependencies": {
-    "@capacitor/core": ">=8.0.0"
+    "@capacitor/core": ">=8.0.0",
+    "@revenuecat/purchases-capacitor": "13.1.7"
   },
   "lint-staged": {
     "*.{ts,js,java,html,css}": [

--- a/purchases-capacitor-ui/package.json
+++ b/purchases-capacitor-ui/package.json
@@ -59,7 +59,7 @@
     "build": "npm run clean && tsc && rollup -c ../rollup.config.js",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "apitest": "npm run build && cd apitesters && npm install && tsc -p .",
+    "apitest": "npm run build && cd apitesters && npm install --legacy-peer-deps && tsc -p .",
     "prepublishOnly": "npm run build",
     "extract-api": "api-extractor run --local --verbose"
   },


### PR DESCRIPTION
## Description

`@revenuecat/purchases-capacitor-ui` is published at `13.1.7` but declared `@revenuecat/purchases-capacitor: "^10.2.4"`, so consumers ended up with two different copies of the core package. Resolves #815.

- Move the core package from `dependencies` to an exact `peerDependencies` entry, matching `react-native-purchases-ui`. The UI's TypeScript never imports it, so a peer dependency avoids a duplicate nested copy and surfaces an npm warning on version mismatch — aligning with our docs' "must match the version" guidance.
- Add the dependency to the Fastfile bump list so future releases keep it in lockstep with the SDK version (the root cause of the drift).
- Because the exact peer tracks the version, dry-run/release bumps point it at a not-yet-published version and npm 7+ fails auto-installing it (`ETARGET`). The two UI installs that resolve the peer without a local core (`purchases-capacitor-ui` and `apitesters`) now pass `--legacy-peer-deps`.