### PR TITLE
ci: validate UI dry-run release against a local Verdaccio registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,11 +137,9 @@ commands:
           command: |
             for i in $(seq 1 90); do curl -fs http://localhost:4873/-/ping > /dev/null && break; sleep 1; done
             curl -fs http://localhost:4873/-/ping > /dev/null || { echo "Verdaccio did not start"; exit 1; }
-            TOKEN=$(curl -s -XPUT -H "Content-type: application/json" \
-              -d '{"name":"ci","password":"ci-verdaccio-password"}' \
-              http://localhost:4873/-/user/org.couchdb.user:ci \
-              | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>process.stdout.write(JSON.parse(d).token))")
-            echo "//localhost:4873/:_authToken=${TOKEN}" >> ~/.npmrc
+            # Verdaccio's `publish: $all` permits anonymous publishing; npm only
+            # requires that *some* auth token is present, which it can't verify.
+            echo "//localhost:4873/:_authToken=anonymous" >> ~/.npmrc
             echo "@revenuecat:registry=http://localhost:4873/" >> ~/.npmrc
             npm publish
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
           key: v2-unix-ui-dependencies-{{ checksum "purchases-capacitor-ui/package.json" }}
       - run:
           name: Install UI package dependencies
-          command: cd purchases-capacitor-ui && npm install --legacy-peer-deps
+          command: cd purchases-capacitor-ui && npm install
       - save_cache:
           paths:
             - purchases-capacitor-ui/node_modules
@@ -97,7 +97,7 @@ commands:
           key: v2-mac-ui-dependencies-{{ checksum "purchases-capacitor-ui/package.json" }}
       - run:
           name: Install UI package dependencies
-          command: cd purchases-capacitor-ui && npm install --legacy-peer-deps
+          command: cd purchases-capacitor-ui && npm install
       - save_cache:
           paths:
             - purchases-capacitor-ui/node_modules
@@ -114,6 +114,36 @@ commands:
       - run:
           name: Copy npmrc sample file to UI package location
           command: cp .npmrc.SAMPLE purchases-capacitor-ui/.npmrc
+
+  publish-core-to-local-registry:
+    description: >
+      The UI package pins @revenuecat/purchases-capacitor to the exact SDK
+      version as a peerDependency. During release and dry-run flows that version
+      isn't on npm yet, so UI installs can't resolve the peer. This starts a
+      local Verdaccio registry, publishes the freshly built core package to it,
+      and scopes @revenuecat installs to it so the peer resolves locally for
+      real (instead of skipping peer resolution). Must run after the root
+      dependencies are installed and before any UI package install.
+    steps:
+      - run:
+          name: Install Verdaccio
+          command: npm install -g verdaccio@6
+      - run:
+          name: Start local registry (Verdaccio)
+          background: true
+          command: verdaccio --config .circleci/verdaccio.yaml --listen 4873
+      - run:
+          name: Publish core package to local registry
+          command: |
+            for i in $(seq 1 90); do curl -fs http://localhost:4873/-/ping > /dev/null && break; sleep 1; done
+            curl -fs http://localhost:4873/-/ping > /dev/null || { echo "Verdaccio did not start"; exit 1; }
+            TOKEN=$(curl -s -XPUT -H "Content-type: application/json" \
+              -d '{"name":"ci","password":"ci-verdaccio-password"}' \
+              http://localhost:4873/-/user/org.couchdb.user:ci \
+              | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>process.stdout.write(JSON.parse(d).token))")
+            echo "//localhost:4873/:_authToken=${TOKEN}" >> ~/.npmrc
+            echo "@revenuecat:registry=http://localhost:4873/" >> ~/.npmrc
+            npm publish
 
 jobs:
   run-tests-ios:
@@ -196,6 +226,7 @@ jobs:
           name: Start booting iOS Simulator
           command: xcrun simctl boot "iPhone 17" || true
       - yarn-dependencies-mac
+      - publish-core-to-local-registry
       - yarn-dependencies-ui-mac
       - run:
           name: Replace Maestro test app API key
@@ -227,6 +258,7 @@ jobs:
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - yarn-dependencies-unix
+      - publish-core-to-local-registry
       - yarn-dependencies-ui-unix
       - run:
           name: Replace Maestro test app API key
@@ -290,6 +322,7 @@ jobs:
     steps:
       - checkout
       - yarn-dependencies-unix
+      - publish-core-to-local-registry
       - yarn-dependencies-ui-unix
       - run: yarn build
       - run:
@@ -313,6 +346,7 @@ jobs:
     steps:
       - checkout
       - yarn-dependencies-unix
+      - publish-core-to-local-registry
       - yarn-dependencies-ui-unix
       - run: yarn build
       - run:
@@ -326,6 +360,7 @@ jobs:
     steps:
       - checkout
       - yarn-dependencies-unix
+      - publish-core-to-local-registry
       - yarn-dependencies-ui-unix
       - run: yarn build
       - run:
@@ -345,34 +380,9 @@ jobs:
           description: Running `npm publish --dry-run` for an existing version fails because the version is already published. This lane temporarily bumps the version to a next version just for testing the publish command.
           command: bundle exec fastlane temporary_bump_version
       - yarn-dependencies-unix
+      - publish-core-to-local-registry
+      - yarn-dependencies-ui-unix
       - run: yarn build
-      - run:
-          name: Install Verdaccio
-          command: npm install -g verdaccio@6
-      - run:
-          name: Start local registry (Verdaccio)
-          background: true
-          command: verdaccio --config .circleci/verdaccio.yaml --listen 4873
-      - run:
-          name: Publish core package to local registry
-          description: >
-            The UI package pins @revenuecat/purchases-capacitor to the exact SDK
-            version as a peerDependency, and after the temporary bump that version
-            isn't on npm yet. Publishing the freshly built core package to the local
-            registry lets the UI install resolve the peer for real, rather than
-            skipping peer resolution with --legacy-peer-deps.
-          command: |
-            for i in $(seq 1 90); do curl -fs http://localhost:4873/-/ping > /dev/null && break; sleep 1; done
-            curl -fs http://localhost:4873/-/ping > /dev/null || { echo "Verdaccio did not start"; exit 1; }
-            TOKEN=$(curl -s -XPUT -H "Content-type: application/json" \
-              -d '{"name":"ci","password":"ci-verdaccio-password"}' \
-              http://localhost:4873/-/user/org.couchdb.user:ci \
-              | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>process.stdout.write(JSON.parse(d).token))")
-            echo "//localhost:4873/:_authToken=${TOKEN}" >> ~/.npmrc
-            npm publish --registry http://localhost:4873/
-      - run:
-          name: Install UI package dependencies from local registry
-          command: cd purchases-capacitor-ui && npm install --registry http://localhost:4873/
       - run:
           name: Build UI package
           command: cd purchases-capacitor-ui && npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,12 +118,12 @@ commands:
   publish-core-to-local-registry:
     description: >
       The UI package pins @revenuecat/purchases-capacitor to the exact SDK
-      version as a peerDependency. During release and dry-run flows that version
-      isn't on npm yet, so UI installs can't resolve the peer. This starts a
-      local Verdaccio registry, publishes the freshly built core package to it,
-      and scopes @revenuecat installs to it so the peer resolves locally for
-      real (instead of skipping peer resolution). Must run after the root
-      dependencies are installed and before any UI package install.
+      version as a peerDependency. During dry-run flows that version isn't on
+      npm yet, so UI installs can't resolve the peer. This starts a local
+      Verdaccio registry, publishes the freshly built core package to it, and
+      scopes @revenuecat installs to it so the peer resolves locally for real.
+      Must run after the root dependencies are installed and before any UI
+      package install.
     steps:
       - run:
           name: Install Verdaccio
@@ -137,11 +137,33 @@ commands:
           command: |
             for i in $(seq 1 90); do curl -fs http://localhost:4873/-/ping > /dev/null && break; sleep 1; done
             curl -fs http://localhost:4873/-/ping > /dev/null || { echo "Verdaccio did not start"; exit 1; }
-            # Verdaccio's `publish: $all` permits anonymous publishing; npm only
-            # requires that *some* auth token is present, which it can't verify.
+            # Route the @revenuecat scope to the local registry with a dummy token
+            # (Verdaccio's `publish: $all` allows anonymous publishing; npm only
+            # requires that *some* token is present, which it can't verify).
             echo "//localhost:4873/:_authToken=anonymous" >> ~/.npmrc
             echo "@revenuecat:registry=http://localhost:4873/" >> ~/.npmrc
-            npm publish
+            # Safety net: never let this publish reach the public npm registry.
+            # Abort unless the @revenuecat scope resolves to the local Verdaccio.
+            resolved="$(npm config get @revenuecat:registry)"
+            case "$resolved" in
+              http://localhost:4873/*) ;;
+              *) echo "Refusing to publish: @revenuecat registry resolved to '$resolved', not local Verdaccio"; exit 1 ;;
+            esac
+            npm publish --registry http://localhost:4873/
+
+  # Installs root deps, publishes the freshly built core to a local registry,
+  # then installs the UI package against it so its exact peer resolves for real.
+  ui-dependencies-unix:
+    steps:
+      - yarn-dependencies-unix
+      - publish-core-to-local-registry
+      - yarn-dependencies-ui-unix
+
+  ui-dependencies-mac:
+    steps:
+      - yarn-dependencies-mac
+      - publish-core-to-local-registry
+      - yarn-dependencies-ui-mac
 
 jobs:
   run-tests-ios:
@@ -223,9 +245,7 @@ jobs:
       - run:
           name: Start booting iOS Simulator
           command: xcrun simctl boot "iPhone 17" || true
-      - yarn-dependencies-mac
-      - publish-core-to-local-registry
-      - yarn-dependencies-ui-mac
+      - ui-dependencies-mac
       - run:
           name: Replace Maestro test app API key
           command: bundle exec fastlane change_maestro_test_app_api_key
@@ -255,9 +275,7 @@ jobs:
       - checkout
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
-      - yarn-dependencies-unix
-      - publish-core-to-local-registry
-      - yarn-dependencies-ui-unix
+      - ui-dependencies-unix
       - run:
           name: Replace Maestro test app API key
           command: bundle exec fastlane change_maestro_test_app_api_key
@@ -319,9 +337,7 @@ jobs:
       - image: cimg/ruby:3.1.2
     steps:
       - checkout
-      - yarn-dependencies-unix
-      - publish-core-to-local-registry
-      - yarn-dependencies-ui-unix
+      - ui-dependencies-unix
       - run: yarn build
       - run:
           name: Extract API (main package)
@@ -343,9 +359,7 @@ jobs:
       - image: cimg/ruby:3.1.2
     steps:
       - checkout
-      - yarn-dependencies-unix
-      - publish-core-to-local-registry
-      - yarn-dependencies-ui-unix
+      - ui-dependencies-unix
       - run: yarn build
       - run:
           name: API Tests (UI)
@@ -357,9 +371,7 @@ jobs:
       - image: cimg/ruby:3.1.2
     steps:
       - checkout
-      - yarn-dependencies-unix
-      - publish-core-to-local-registry
-      - yarn-dependencies-ui-unix
+      - ui-dependencies-unix
       - run: yarn build
       - run:
           name: Lint UI package
@@ -377,9 +389,7 @@ jobs:
           name: Temporarily bump version
           description: Running `npm publish --dry-run` for an existing version fails because the version is already published. This lane temporarily bumps the version to a next version just for testing the publish command.
           command: bundle exec fastlane temporary_bump_version
-      - yarn-dependencies-unix
-      - publish-core-to-local-registry
-      - yarn-dependencies-ui-unix
+      - ui-dependencies-unix
       - run: yarn build
       - run:
           name: Build UI package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,8 +345,34 @@ jobs:
           description: Running `npm publish --dry-run` for an existing version fails because the version is already published. This lane temporarily bumps the version to a next version just for testing the publish command.
           command: bundle exec fastlane temporary_bump_version
       - yarn-dependencies-unix
-      - yarn-dependencies-ui-unix
       - run: yarn build
+      - run:
+          name: Install Verdaccio
+          command: npm install -g verdaccio@6
+      - run:
+          name: Start local registry (Verdaccio)
+          background: true
+          command: verdaccio --config .circleci/verdaccio.yaml --listen 4873
+      - run:
+          name: Publish core package to local registry
+          description: >
+            The UI package pins @revenuecat/purchases-capacitor to the exact SDK
+            version as a peerDependency, and after the temporary bump that version
+            isn't on npm yet. Publishing the freshly built core package to the local
+            registry lets the UI install resolve the peer for real, rather than
+            skipping peer resolution with --legacy-peer-deps.
+          command: |
+            for i in $(seq 1 90); do curl -fs http://localhost:4873/-/ping > /dev/null && break; sleep 1; done
+            curl -fs http://localhost:4873/-/ping > /dev/null || { echo "Verdaccio did not start"; exit 1; }
+            TOKEN=$(curl -s -XPUT -H "Content-type: application/json" \
+              -d '{"name":"ci","password":"ci-verdaccio-password"}' \
+              http://localhost:4873/-/user/org.couchdb.user:ci \
+              | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>process.stdout.write(JSON.parse(d).token))")
+            echo "//localhost:4873/:_authToken=${TOKEN}" >> ~/.npmrc
+            npm publish --registry http://localhost:4873/
+      - run:
+          name: Install UI package dependencies from local registry
+          command: cd purchases-capacitor-ui && npm install --registry http://localhost:4873/
       - run:
           name: Build UI package
           command: cd purchases-capacitor-ui && npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
           key: v2-unix-ui-dependencies-{{ checksum "purchases-capacitor-ui/package.json" }}
       - run:
           name: Install UI package dependencies
-          command: cd purchases-capacitor-ui && npm install
+          command: cd purchases-capacitor-ui && npm install --legacy-peer-deps
       - save_cache:
           paths:
             - purchases-capacitor-ui/node_modules
@@ -97,7 +97,7 @@ commands:
           key: v2-mac-ui-dependencies-{{ checksum "purchases-capacitor-ui/package.json" }}
       - run:
           name: Install UI package dependencies
-          command: cd purchases-capacitor-ui && npm install
+          command: cd purchases-capacitor-ui && npm install --legacy-peer-deps
       - save_cache:
           paths:
             - purchases-capacitor-ui/node_modules

--- a/.circleci/verdaccio.yaml
+++ b/.circleci/verdaccio.yaml
@@ -13,7 +13,12 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 packages:
-  # Everything is publishable and readable; non-local packages proxy to npm.
+  # The core package is served purely locally (no uplink) so we can publish a
+  # version that may also already exist on npm without a conflict.
+  '@revenuecat/purchases-capacitor':
+    access: $all
+    publish: $all
+  # Everything else (incl. other @revenuecat packages) proxies to npm.
   '**':
     access: $all
     publish: $all

--- a/.circleci/verdaccio.yaml
+++ b/.circleci/verdaccio.yaml
@@ -1,0 +1,21 @@
+# Verdaccio config used by the `dry-run-release-ui` CI job to spin up a local
+# npm registry. After the temporary version bump, the UI package's exact
+# peerDependency on @revenuecat/purchases-capacitor points at a version that
+# isn't on npm yet. We publish the freshly built core package here so the UI
+# install can resolve the peer for real instead of skipping it.
+storage: /tmp/verdaccio/storage
+auth:
+  htpasswd:
+    file: /tmp/verdaccio/htpasswd
+    # Allow registering the throwaway CI user used to obtain a publish token.
+    max_users: 1000
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  # Everything is publishable and readable; non-local packages proxy to npm.
+  '**':
+    access: $all
+    publish: $all
+    proxy: npmjs
+log: { type: stdout, format: pretty, level: warn }

--- a/.circleci/verdaccio.yaml
+++ b/.circleci/verdaccio.yaml
@@ -7,8 +7,8 @@ storage: /tmp/verdaccio/storage
 auth:
   htpasswd:
     file: /tmp/verdaccio/htpasswd
-    # Allow registering the throwaway CI user used to obtain a publish token.
-    max_users: 1000
+    # No user registration needed: we publish anonymously (see `publish: $all`).
+    max_users: -1
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/

--- a/.circleci/verdaccio.yaml
+++ b/.circleci/verdaccio.yaml
@@ -1,8 +1,9 @@
-# Verdaccio config used by the `dry-run-release-ui` CI job to spin up a local
-# npm registry. After the temporary version bump, the UI package's exact
-# peerDependency on @revenuecat/purchases-capacitor points at a version that
-# isn't on npm yet. We publish the freshly built core package here so the UI
-# install can resolve the peer for real instead of skipping it.
+# Verdaccio config used by CI jobs to spin up a local npm registry (see the
+# `publish-core-to-local-registry` command in config.yml). The UI package's
+# exact peerDependency on @revenuecat/purchases-capacitor can point at a version
+# that isn't on npm yet (e.g. after a dry-run version bump). We publish the
+# freshly built core package here so the UI install can resolve the peer for
+# real instead of skipping it.
 storage: /tmp/verdaccio/storage
 auth:
   htpasswd:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,7 @@
 files_with_version_number = {
     './.version' => ['{x}'],
     './package.json' => ['"version": "{x}"'],
-    './purchases-capacitor-ui/package.json' => ['"version": "{x}"'],
+    './purchases-capacitor-ui/package.json' => ['"version": "{x}"', '"@revenuecat/purchases-capacitor": "{x}"'],
     './ios/Sources/RevenuecatPurchasesCapacitor/PurchasesPlugin.swift' => ['platformVersion = "{x}"'],
     './android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt' => ['PLUGIN_VERSION = "{x}"']
 }

--- a/purchases-capacitor-ui/package.json
+++ b/purchases-capacitor-ui/package.json
@@ -59,7 +59,7 @@
     "build": "npm run clean && tsc && rollup -c ../rollup.config.js",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "apitest": "npm run build && cd apitesters && npm install --legacy-peer-deps && tsc -p .",
+    "apitest": "npm run build && cd apitesters && npm install && tsc -p .",
     "prepublishOnly": "npm run build",
     "extract-api": "api-extractor run --local --verbose"
   },

--- a/purchases-capacitor-ui/package.json
+++ b/purchases-capacitor-ui/package.json
@@ -65,11 +65,11 @@
   },
   "dependencies": {
     "@capacitor/core": "^8.0.0",
-    "@revenuecat/purchases-capacitor": "^10.2.4",
     "@revenuecat/purchases-typescript-internal-esm": "18.15.1"
   },
   "peerDependencies": {
-    "@capacitor/core": ">=8.0.0"
+    "@capacitor/core": ">=8.0.0",
+    "@revenuecat/purchases-capacitor": "13.1.7"
   },
   "lint-staged": {
     "*.{ts,js,java,html,css}": [

--- a/purchases-capacitor-ui/package.json
+++ b/purchases-capacitor-ui/package.json
@@ -59,7 +59,7 @@
     "build": "npm run clean && tsc && rollup -c ../rollup.config.js",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "apitest": "npm run build && cd apitesters && npm install && tsc -p .",
+    "apitest": "npm run build && cd apitesters && npm install --legacy-peer-deps && tsc -p .",
     "prepublishOnly": "npm run build",
     "extract-api": "api-extractor run --local --verbose"
   },


### PR DESCRIPTION
## Description

Follow up to #816, which makes the core package an exact `peerDependency` of the UI package and relies on `--legacy-peer-deps` so installs tolerate the not-yet-published version during dry-run flows. This PR removes that flag and resolves the peer for real against a local registry.

- Adds a reusable `publish-core-to-local-registry` command: starts a local **Verdaccio** registry (`.circleci/verdaccio.yaml`), publishes the freshly built core package to it, and scopes `@revenuecat` installs there. Core is then served locally (no `uplink`) so a version that also exists on npm doesn't conflict.
- Wired into every job doing a standalone UI install against a possibly-unpublished version; `make-release-ui` is excluded (since core package is already on npm by then).
- Guards the `npm publish` command so it can't reach public npm: explicit local `--registry` plus a pre-flight assertion on the resolved `@revenuecat` registry.
- Trade-off: these jobs now build + publish the core to Verdaccio each run, adding some CI time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI and local registry wiring; publish steps include explicit registry scoping and a guard against accidental public npm publish.
> 
> **Overview**
> Replaces **`--legacy-peer-deps`** on UI package installs with a CI flow that **publishes the built core SDK to a local Verdaccio registry** so the UI’s exact `@revenuecat/purchases-capacitor` peer can install normally when that version is not on npm yet (e.g. after a dry-run version bump).
> 
> Adds **`publish-core-to-local-registry`** (Verdaccio + `.circleci/verdaccio.yaml`, wait-for-ready, scope `@revenuecat` to localhost, pre-flight registry check, then `npm publish` only to local Verdaccio) and **`ui-dependencies-unix` / `ui-dependencies-mac`** (root deps → local publish → UI `npm install`). Maestro E2E, API-change checks, UI API tests, lint, and **`dry-run-release-ui`** use those composites; **`make-release-ui`** still does a plain UI install because core is already on npm.
> 
> Also drops **`--legacy-peer-deps`** from the UI **`apitest`** script’s apitesters install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fdb39052bc854572769eeac517251ea03ca69e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->