### PR TITLE
Update sdks-common-config orb to 3.21.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   macos: circleci/macos@2.3.6
   android: circleci/android@3.0.2
   node: circleci/node@5.1.0
-  revenuecat: revenuecat/sdks-common-config@3.16.0
+  revenuecat: revenuecat/sdks-common-config@3.21.2
 
 aliases:
   base-mac-job: &base-mac-job


### PR DESCRIPTION
### Motivation
Pull in [sdks-circleci-orb#69](https://github.com/RevenueCat/sdks-circleci-orb/pull/69), which fixes the `merge-release-pr` job failing after a successful merge.

### Description
Bump the CircleCI orb to `3.21.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI orb version bump with no application or runtime code changes; risk is limited to pipeline behavior differences from the orb update.
> 
> **Overview**
> Bumps the **`revenuecat/sdks-common-config`** CircleCI orb from **3.16.0** to **3.21.2** in `.circleci/config.yml`.
> 
> This picks up the upstream fix for **`revenuecat/merge-release-pr`** failing after a successful release merge (see sdks-circleci-orb#69). All existing jobs that use the orb (gems, Maestro, Danger, tag/merge release workflow, etc.) now run against the newer orb definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74109ffd3f6fdb211e8bd30065bd286ef4e478a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->