### PR TITLE
feat: Expose autoResumeDate/displayName/managementURL/productPlanIdentifier on SubscriptionInfo

### DIFF
--- a/apitesters/src/customerInfo.ts
+++ b/apitesters/src/customerInfo.ts
@@ -79,6 +79,10 @@ function checkSubscriptionInfo(info: PurchasesSubscriptionInfo) {
   const storeTransactionId: string | null = info.storeTransactionId;
   const isActive: boolean = info.isActive;
   const willRenew: boolean = info.willRenew;
+  const autoResumeDate: string | null = info.autoResumeDate;
+  const displayName: string | null = info.displayName;
+  const managementURL: string | null = info.managementURL;
+  const productPlanIdentifier: string | null = info.productPlanIdentifier;
 }
 
 function checkTransaction(transaction: PurchasesStoreTransaction) {


### PR DESCRIPTION
Adds apitester coverage for the new SubscriptionInfo fields (autoResumeDate, displayName, managementURL, productPlanIdentifier) and subscriptionsByProductIdentifier on CustomerInfo.

The field exposure itself shipped via the 18.18.0 auto-bump (https://github.com/RevenueCat/purchases-hybrid-common/pull/1698). Since this repo just passes that through, this PR just adds tests to verify the API.

Part of SDK-4369.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only type assertions with no runtime or security impact.
> 
> **Overview**
> Extends the **`PurchasesSubscriptionInfo`** compile-time checks in `apitesters/src/customerInfo.ts` so **`checkSubscriptionInfo`** also reads **`autoResumeDate`**, **`displayName`**, **`managementURL`**, and **`productPlanIdentifier`** (each `string | null`), matching the new subscription fields from hybrid-common.
> 
> This keeps the Capacitor API tester in sync with the updated **`SubscriptionInfo`** surface so TypeScript consumers can rely on those properties without assignment errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2afc609fd0b1e7196f3ce97f3830fcd40ec78771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->