### PR TITLE
Fix prettier formatting in UI apitesters definitions

### DIFF
--- a/purchases-capacitor-ui/apitesters/src/definitions.ts
+++ b/purchases-capacitor-ui/apitesters/src/definitions.ts
@@ -82,16 +82,16 @@ function checkPaywallListener(listener: PaywallListener) {
   const onPurchaseStarted: ((args: { packageBeingPurchased: PurchasesPackage }) => void) | undefined =
     listener.onPurchaseStarted;
   const onPurchaseCompleted:
-    | ((args: { customerInfo: CustomerInfo; storeTransaction: PurchasesStoreTransaction }) => void)
-    | undefined = listener.onPurchaseCompleted;
+    ((args: { customerInfo: CustomerInfo; storeTransaction: PurchasesStoreTransaction }) => void) | undefined =
+    listener.onPurchaseCompleted;
   const onPurchaseError: ((args: { error: PurchasesError }) => void) | undefined = listener.onPurchaseError;
   const onPurchaseCancelled: (() => void) | undefined = listener.onPurchaseCancelled;
   const onRestoreStarted: (() => void) | undefined = listener.onRestoreStarted;
   const onRestoreCompleted: ((args: { customerInfo: CustomerInfo }) => void) | undefined = listener.onRestoreCompleted;
   const onRestoreError: ((args: { error: PurchasesError }) => void) | undefined = listener.onRestoreError;
   const onPurchaseInitiated:
-    | ((args: { packageBeingPurchased: PurchasesPackage; resumable: PurchaseResumable }) => void)
-    | undefined = listener.onPurchaseInitiated;
+    ((args: { packageBeingPurchased: PurchasesPackage; resumable: PurchaseResumable }) => void) | undefined =
+    listener.onPurchaseInitiated;
 }
 
 function checkPurchaseResumable(resumable: PurchaseResumable) {


### PR DESCRIPTION
Currently blocking PRs due to newer prettier version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace-only formatting in compile-time apitester typings; no logic or public API changes.
> 
> **Overview**
> Updates **`purchases-capacitor-ui/apitesters/src/definitions.ts`** so it passes the repo’s newer Prettier rules—no API or runtime behavior changes.
> 
> In `checkPaywallListener`, the `onPurchaseCompleted` and `onPurchaseInitiated` callback types are reformatted from a leading-pipe multiline union to the style Prettier expects (type after `:` with `| undefined` on the following line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276c068e453d8a6983a09820e9a8d8cad8059c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->