### PR TITLE
ci: bump orb to 4.5.0 and local Ruby images to 3.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   macos: circleci/macos@2.3.6
   android: circleci/android@3.0.2
   node: circleci/node@5.1.0
-  revenuecat: revenuecat/sdks-common-config@4.4.0
+  revenuecat: revenuecat/sdks-common-config@4.5.0
 
 aliases:
   base-mac-job: &base-mac-job
@@ -153,7 +153,7 @@ jobs:
 
   run-api-tests:
     docker:
-      - image: cimg/ruby:3.1.2
+      - image: cimg/ruby:3.2.0
     steps:
       - checkout
       - yarn-dependencies-unix
@@ -164,7 +164,7 @@ jobs:
 
   run-lint:
     docker:
-      - image: cimg/ruby:3.1.2
+      - image: cimg/ruby:3.2.0
     steps:
       - checkout
       - yarn-dependencies-unix
@@ -272,7 +272,7 @@ jobs:
     description: >
       Runs automatic bump
     docker:
-      - image: cimg/ruby:3.1.2
+      - image: cimg/ruby:3.2.0
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
@@ -288,7 +288,7 @@ jobs:
   check-api-changes:
     description: "Check for unexpected API changes in purchases-capacitor and purchases-capacitor-ui"
     docker:
-      - image: cimg/ruby:3.1.2
+      - image: cimg/ruby:3.2.0
     steps:
       - checkout
       - yarn-dependencies-unix
@@ -311,7 +311,7 @@ jobs:
   run-api-tests-ui:
     description: "Run API tests for purchases-capacitor-ui package"
     docker:
-      - image: cimg/ruby:3.1.2
+      - image: cimg/ruby:3.2.0
     steps:
       - checkout
       - yarn-dependencies-unix
@@ -324,7 +324,7 @@ jobs:
   run-lint-ui:
     description: "Run linting for purchases-capacitor-ui package"
     docker:
-      - image: cimg/ruby:3.1.2
+      - image: cimg/ruby:3.2.0
     steps:
       - checkout
       - yarn-dependencies-unix
@@ -337,7 +337,7 @@ jobs:
   dry-run-release-ui:
     description: "Validate purchases-capacitor-ui package can be published"
     docker:
-      - image: cimg/ruby:3.1.2
+      - image: cimg/ruby:3.2.0
     steps:
       - checkout
       - revenuecat/install-gem-unix-dependencies:


### PR DESCRIPTION
### Motivation

The `danger` job relied on the orb's old default Ruby `3.1.2`, and the repo's local bump/release jobs hardcode `cimg/ruby:3.1.2`. That Ruby no longer satisfies gems requiring Ruby >= 3.2 — `bundle install` fails as Bundler backtracks to an unbuildable `nokogiri`.

### Summary

- Bump `revenuecat/sdks-common-config` to `4.5.0` (defaults `danger` to Ruby 3.2.0, sdks-circleci-orb#81).
- Bump the local job images from `cimg/ruby:3.1.2` to `3.2.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only image and orb version bumps with no application or runtime code changes; main risk is transient pipeline breakage if Ruby 3.2.0 behaves differently in Fastlane/gem installs.
> 
> **Overview**
> Updates CircleCI so Ruby **3.2.0** is used everywhere CI runs `bundle install` / Fastlane, fixing gem resolution failures (e.g. dependencies requiring Ruby ≥ 3.2 and broken `nokogiri` backtracking on 3.1.2).
> 
> **`revenuecat/sdks-common-config`** moves from **4.4.0** to **4.5.0**, which aligns the orb **`danger`** job with Ruby 3.2.0. Local Docker jobs that previously pinned **`cimg/ruby:3.1.2`**—API tests, lint, bump, API change checks, and UI package test/lint/dry-run release—now use **`cimg/ruby:3.2.0`**. Mac/Xcode jobs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27947475837df88cebeb87704f64b6fa2000ea9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->