### PR TITLE
chore: bump fastlane-plugin-revenuecat_internal to unblock hybrid bumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: dab67655d71eaf08b40f74339e4bb17d16436c32
+  revision: 9b928b6ca92e965ecb7d63edb810e9343975f3de
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri


### PR DESCRIPTION
### Motivation
Hybrid version bumps crash in `update_hybrids_versions_file` with `undefined method 'captures' for nil:NilClass`, because the plugin looked up a removed `bc8` key in purchases-android's `libs.versions.toml`.

### Summary
- Bump the pinned `fastlane-plugin-revenuecat_internal` revision to `main` HEAD, which includes the fix (RevenueCat/fastlane-plugin-revenuecat_internal#145).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin-only change for internal release tooling; no app runtime or security surface affected.
> 
> **Overview**
> Updates the **pinned git revision** for `fastlane-plugin-revenuecat_internal` in `Gemfile.lock` from `dab67655…` to `9b928b6…` (plugin `main` with fix from RevenueCat/fastlane-plugin-revenuecat_internal#145).
> 
> This pulls in the fix for hybrid version bumps failing in `update_hybrids_versions_file` with `undefined method 'captures' for nil:NilClass` when the plugin still expected a removed `bc8` entry in purchases-android’s `libs.versions.toml`. No other gems or lockfile entries change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05b934fc5b5e71a3c058ddc2de3fdede939ab0a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->