### PR TITLE
Add internal support for enabling workflows

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
+++ b/android/src/main/java/com/revenuecat/purchases/capacitor/PurchasesPlugin.kt
@@ -9,6 +9,8 @@ import com.getcapacitor.PluginCall
 import com.getcapacitor.PluginMethod
 import com.getcapacitor.annotation.CapacitorPlugin
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.DangerousSettings
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.Store
@@ -92,6 +94,7 @@ class PurchasesPlugin : Plugin() {
     }
 
     @PluginMethod(returnType = PluginMethod.RETURN_NONE)
+    @OptIn(InternalRevenueCatAPI::class)
     fun configure(call: PluginCall) {
         val apiKey = call.getStringOrReject("apiKey") ?: return
         val appUserID = call.getString("appUserID")
@@ -110,6 +113,8 @@ class PurchasesPlugin : Plugin() {
         val diagnosticsEnabled = call.getBoolean("diagnosticsEnabled")
         val automaticDeviceIdentifierCollectionEnabled = call.getBoolean("automaticDeviceIdentifierCollectionEnabled")
         val preferredLocale = call.getString("preferredUILocaleOverride")
+        val useWorkflows = call.getObject("dangerousSettings")?.getBool("useWorkflows") ?: false
+        val dangerousSettings = if (useWorkflows) DangerousSettings.forWorkflows(true) else DangerousSettings()
 
         configure(
             context.applicationContext,
@@ -118,6 +123,7 @@ class PurchasesPlugin : Plugin() {
             purchasesAreCompletedBy,
             platformInfo,
             store,
+            dangerousSettings = dangerousSettings,
             shouldShowInAppMessagesAutomatically = shouldShowInAppMessages,
             verificationMode = entitlementVerificationMode,
             pendingTransactionsForPrepaidPlansEnabled = pendingTransactionsForPrepaidPlansEnabled,

--- a/ios/Sources/RevenuecatPurchasesCapacitor/PurchasesPlugin.swift
+++ b/ios/Sources/RevenuecatPurchasesCapacitor/PurchasesPlugin.swift
@@ -3,7 +3,7 @@
 import Foundation
 import Capacitor
 import PurchasesHybridCommon
-import RevenueCat
+@_spi(Internal) import RevenueCat
 
 /**
  * Please read the Capacitor iOS Plugin Development Guide
@@ -133,15 +133,17 @@ public class PurchasesPlugin: CAPPlugin, PurchasesDelegate, CAPBridgedPlugin {
         let diagnosticsEnabled = call.getBool("diagnosticsEnabled") ?? false
         let automaticDeviceIdentifierCollectionEnabled = call.getBool("automaticDeviceIdentifierCollectionEnabled") ?? true
         let preferredLocale = call.getString("preferredUILocaleOverride")
+        let useWorkflows = call.getObject("dangerousSettings")?["useWorkflows"] as? Bool ?? false
+        let dangerousSettings = useWorkflows ? DangerousSettings(useWorkflows: true) : DangerousSettings()
 
-        let purchases = Purchases.configure(apiKey: apiKey,
+        let purchases = Purchases.configure(apiKey: (apiKey),
                                             appUserID: appUserID,
                                             purchasesAreCompletedBy: purchasesAreCompletedBy,
                                             userDefaultsSuiteName: userDefaultsSuiteName,
                                             platformFlavor: self.platformFlavor,
                                             platformFlavorVersion: self.platformVersion,
                                             storeKitVersion: storeKitVersion,
-                                            dangerousSettings: DangerousSettings(),
+                                            dangerousSettings: dangerousSettings,
                                             shouldShowInAppMessagesAutomatically: shouldShowInAppMessagesAutomatically,
                                             verificationMode: entitlementVerificationMode,
                                             diagnosticsEnabled: diagnosticsEnabled,


### PR DESCRIPTION
## What changed

Wires the existing internal `dangerousSettings.useWorkflows` configure option into the Capacitor native bridges, defaulting to `false` when absent.

- Android uses `DangerousSettings.forWorkflows(true)` when enabled.
- iOS uses the `@_spi(Internal)` `DangerousSettings(useWorkflows:)` initializer.

## Verification
- [x] `yarn build`
- [x] `yarn lint`
- [x] `npm run verify:android`
- [x] `npm run verify:ios` (SPM and CocoaPods installation builds)

This mirrors purchases-unity#996 and react-native-purchases#1847. Defaults remain unchanged when the option is omitted.