### PR TITLE
Add onWebCheckoutOpened and onUrlOpened to the paywall listener

### DIFF
--- a/purchases-capacitor-ui/android/src/main/java/com/revenuecat/purchases/capacitor/ui/RevenueCatUIPlugin.kt
+++ b/purchases-capacitor-ui/android/src/main/java/com/revenuecat/purchases/capacitor/ui/RevenueCatUIPlugin.kt
@@ -258,6 +258,12 @@ class RevenueCatUIPlugin : Plugin(), PaywallResultListener {
                 notifyListeners("onWebCheckoutOpened", JSObject())
             }
 
+            override fun onUrlOpened(url: String) {
+                notifyListeners("onUrlOpened", JSObject().apply {
+                    put("url", url)
+                })
+            }
+
             override fun onPurchasePackageInitiated(rcPackage: Map<String, Any?>, requestId: String) {
                 notifyListeners("onPurchaseInitiated", JSObject().apply {
                     put("package", JSONObject(rcPackage))

--- a/purchases-capacitor-ui/android/src/main/java/com/revenuecat/purchases/capacitor/ui/RevenueCatUIPlugin.kt
+++ b/purchases-capacitor-ui/android/src/main/java/com/revenuecat/purchases/capacitor/ui/RevenueCatUIPlugin.kt
@@ -254,6 +254,10 @@ class RevenueCatUIPlugin : Plugin(), PaywallResultListener {
                 })
             }
 
+            override fun onWebCheckoutOpened() {
+                notifyListeners("onWebCheckoutOpened", JSObject())
+            }
+
             override fun onPurchasePackageInitiated(rcPackage: Map<String, Any?>, requestId: String) {
                 notifyListeners("onPurchaseInitiated", JSObject().apply {
                     put("package", JSONObject(rcPackage))

--- a/purchases-capacitor-ui/api-report/purchases-capacitor-ui.api.md
+++ b/purchases-capacitor-ui/api-report/purchases-capacitor-ui.api.md
@@ -56,6 +56,9 @@ export interface PaywallListener {
         error: PurchasesError;
     }) => void;
     onRestoreStarted?: () => void;
+    onUrlOpened?: (args: {
+        url: string;
+    }) => void;
     onWebCheckoutOpened?: () => void;
 }
 

--- a/purchases-capacitor-ui/api-report/purchases-capacitor-ui.api.md
+++ b/purchases-capacitor-ui/api-report/purchases-capacitor-ui.api.md
@@ -56,6 +56,7 @@ export interface PaywallListener {
         error: PurchasesError;
     }) => void;
     onRestoreStarted?: () => void;
+    onWebCheckoutOpened?: () => void;
 }
 
 // @public

--- a/purchases-capacitor-ui/apitesters/src/revenuecatui.ts
+++ b/purchases-capacitor-ui/apitesters/src/revenuecatui.ts
@@ -87,6 +87,7 @@ async function checkPaywallListener(plugin: RevenueCatUIPlugin) {
     onRestoreStarted: () => {},
     onRestoreCompleted: (args: { customerInfo: CustomerInfo }) => {},
     onRestoreError: (args: { error: PurchasesError }) => {},
+    onWebCheckoutOpened: () => {},
     onPurchaseInitiated: (args: { packageBeingPurchased: PurchasesPackage; resumable: PurchaseResumable }) => {
       args.resumable.resume();
       args.resumable.resume(true);

--- a/purchases-capacitor-ui/apitesters/src/revenuecatui.ts
+++ b/purchases-capacitor-ui/apitesters/src/revenuecatui.ts
@@ -88,6 +88,7 @@ async function checkPaywallListener(plugin: RevenueCatUIPlugin) {
     onRestoreCompleted: (args: { customerInfo: CustomerInfo }) => {},
     onRestoreError: (args: { error: PurchasesError }) => {},
     onWebCheckoutOpened: () => {},
+    onUrlOpened: (args: { url: string }) => {},
     onPurchaseInitiated: (args: { packageBeingPurchased: PurchasesPackage; resumable: PurchaseResumable }) => {
       args.resumable.resume();
       args.resumable.resume(true);

--- a/purchases-capacitor-ui/ios/Sources/RevenuecatPurchasesCapacitorUI/RevenueCatUIPlugin.swift
+++ b/purchases-capacitor-ui/ios/Sources/RevenuecatPurchasesCapacitorUI/RevenueCatUIPlugin.swift
@@ -271,6 +271,10 @@ private class PaywallDelegateAdapter: NSObject, PaywallViewControllerDelegateWra
         plugin?.notifyListeners("onRestoreError", data: ["error": errorDictionary])
     }
 
+    func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController) {
+        plugin?.notifyListeners("onWebCheckoutOpened", data: [:])
+    }
+
     func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {
         plugin?.notifyListeners("paywallDismissed", data: [:])
     }

--- a/purchases-capacitor-ui/ios/Sources/RevenuecatPurchasesCapacitorUI/RevenueCatUIPlugin.swift
+++ b/purchases-capacitor-ui/ios/Sources/RevenuecatPurchasesCapacitorUI/RevenueCatUIPlugin.swift
@@ -276,8 +276,8 @@ private class PaywallDelegateAdapter: NSObject, PaywallViewControllerDelegateWra
     }
 
     func paywallViewController(_ controller: PaywallViewController,
-                                didOpenURL url: URL) {
-        plugin?.notifyListeners("onUrlOpened", data: ["url": url.absoluteString])
+                                didOpenURL url: String) {
+        plugin?.notifyListeners("onUrlOpened", data: ["url": url])
     }
 
     func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {

--- a/purchases-capacitor-ui/ios/Sources/RevenuecatPurchasesCapacitorUI/RevenueCatUIPlugin.swift
+++ b/purchases-capacitor-ui/ios/Sources/RevenuecatPurchasesCapacitorUI/RevenueCatUIPlugin.swift
@@ -275,6 +275,11 @@ private class PaywallDelegateAdapter: NSObject, PaywallViewControllerDelegateWra
         plugin?.notifyListeners("onWebCheckoutOpened", data: [:])
     }
 
+    func paywallViewController(_ controller: PaywallViewController,
+                                didOpenURL url: URL) {
+        plugin?.notifyListeners("onUrlOpened", data: ["url": url.absoluteString])
+    }
+
     func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {
         plugin?.notifyListeners("paywallDismissed", data: [:])
     }

--- a/purchases-capacitor-ui/src/definitions.ts
+++ b/purchases-capacitor-ui/src/definitions.ts
@@ -81,6 +81,8 @@ export interface PaywallListener {
   onRestoreCompleted?: (args: { customerInfo: CustomerInfo }) => void;
   /** Called when a restore operation fails with an error. */
   onRestoreError?: (args: { error: PurchasesError }) => void;
+  /** Called when the user taps a web checkout CTA and leaves the app to complete payment externally. */
+  onWebCheckoutOpened?: () => void;
   /**
    * Called before the payment sheet is displayed, allowing the app to gate
    * the purchase flow (e.g., require authentication first).

--- a/purchases-capacitor-ui/src/definitions.ts
+++ b/purchases-capacitor-ui/src/definitions.ts
@@ -83,6 +83,8 @@ export interface PaywallListener {
   onRestoreError?: (args: { error: PurchasesError }) => void;
   /** Called when the user taps a web checkout CTA and leaves the app to complete payment externally. */
   onWebCheckoutOpened?: () => void;
+  /** Called when the paywall opens a URL from a button destination or a text link. Not called for web checkout. */
+  onUrlOpened?: (args: { url: string }) => void;
   /**
    * Called before the payment sheet is displayed, allowing the app to gate
    * the purchase flow (e.g., require authentication first).

--- a/purchases-capacitor-ui/src/index.ts
+++ b/purchases-capacitor-ui/src/index.ts
@@ -183,6 +183,14 @@ async function presentWithListenerSupport(
           }),
         );
       }
+      if (listener.onWebCheckoutOpened) {
+        const cb = listener.onWebCheckoutOpened;
+        handles.push(
+          await nativePlugin.addListener('onWebCheckoutOpened', () => {
+            cb();
+          }),
+        );
+      }
     }
 
     // Always register onPurchaseInitiated so we auto-resume when the user

--- a/purchases-capacitor-ui/src/index.ts
+++ b/purchases-capacitor-ui/src/index.ts
@@ -191,6 +191,14 @@ async function presentWithListenerSupport(
           }),
         );
       }
+      if (listener.onUrlOpened) {
+        const cb = listener.onUrlOpened;
+        handles.push(
+          await nativePlugin.addListener('onUrlOpened', (data: any) => {
+            cb({ url: data.url });
+          }),
+        );
+      }
     }
 
     // Always register onPurchaseInitiated so we auto-resume when the user


### PR DESCRIPTION
Adds `onWebCheckoutOpened` and `onUrlOpened` to the `PaywallListener`, forwarding the native paywall listener events (available in PHC 18.29.0).

- `onWebCheckoutOpened`: the user tapped a web checkout CTA and left the app to pay externally.
- `onUrlOpened({ url })`: the paywall opened a URL from a button URL destination or a text-component link. Not called for web checkout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, optional listener API with no changes to purchase or restore flows; risk is limited to apps that opt into the new callbacks.
> 
> **Overview**
> Extends **`PaywallListener`** with two optional callbacks that mirror native paywall delegate events from PHC 18.29.0, so Capacitor apps can react when users leave the app for web checkout or when the paywall opens a link.
> 
> **`onWebCheckoutOpened`** fires when the user taps a web-checkout CTA and the app hands off to external payment. **`onUrlOpened({ url })`** fires when the paywall opens a URL from a button destination or text link (not web checkout).
> 
> The TypeScript layer registers native `onWebCheckoutOpened` / `onUrlOpened` listeners in `presentWithListenerSupport` when those callbacks are provided. Android forwards overrides on `PaywallListenerWrapper`; iOS maps `paywallViewControllerDidOpenWebCheckout` and `didOpenURL` in the delegate adapter. Public API report and apitesters are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3757c7aa601db29645c418f80ffa3208213578db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->