### PR TITLE
Bump shared issue-notifications workflow to v6 (fix disallowed action error)

### DIFF
--- a/.github/workflows/issue-notifications.yml
+++ b/.github/workflows/issue-notifications.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   notify:
-    uses: revenuecat/sdk-github-workflows/.github/workflows/issue-notifications.yml@acb41efc0045b05dd0517dc08200dd4112ea9bae # v2
+    uses: revenuecat/sdk-github-workflows/.github/workflows/issue-notifications.yml@6e9dc0b902ff4a1118d62eab4346d578a0bcdec9 # v6
     secrets:
       ACK_SLACK_WEBHOOK_URL: ${{ secrets.ACK_SLACK_WEBHOOK_URL }}
       ACK_ALERT_KEYWORDS: ${{ secrets.ACK_ALERT_KEYWORDS }}


### PR DESCRIPTION
### Why

The Issue Notifications workflow is failing in all SDK repos:

> The action joshdholtz/github-action-issue-ack@v17 is not allowed ... All actions must also be pinned to a full-length commit SHA.

The repos pin the shared `sdk-github-workflows/issue-notifications.yml` at v2, which used the action via a tag (`@v17`). The SHA-pinning fix landed in RevenueCat/sdk-github-workflows#9 and is now tagged v6.

### What

Bump the reusable workflow ref from v2 (`acb41ef`) to v6 (`6e9dc0b`). The only change to `issue-notifications.yml` between those refs is pinning `joshdholtz/github-action-issue-ack` to a full commit SHA.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line workflow ref bump with no application or secret changes; only affects CI notifications.
> 
> **Overview**
> Updates the **Issue Notifications** job to call the shared `revenuecat/sdk-github-workflows` reusable workflow at **v6** (`6e9dc0b`) instead of **v2** (`acb41ef`).
> 
> That upstream bump pins `joshdholtz/github-action-issue-ack` to a full commit SHA instead of `@v17`, which restores the workflow after org policy blocked tag-pinned third-party actions. Local triggers, schedule, and Slack/ACK secret wiring are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab2b2bf848823c040dd73fea4e0996088963ba6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->