### PR TITLE
Wire mise into CI for Node, Ruby, and JDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 orbs:
   macos: circleci/macos@2.3.6
   android: circleci/android@3.0.2
-  node: circleci/node@5.1.0
   revenuecat: revenuecat/sdks-common-config@4.5.1
 
 aliases:
@@ -59,8 +58,8 @@ parameters:
 commands:
   install-nvm:
     steps:
-      - node/install:
-          install-yarn: true
+      - revenuecat/install-mise-tools:
+          tools: node
 
   yarn-dependencies-unix:
     description: "Install yarn dependencies"
@@ -170,6 +169,8 @@ jobs:
     <<: *base-mac-job
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: ruby
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - yarn-dependencies-mac
@@ -180,8 +181,8 @@ jobs:
     <<: *base-android-job
     steps:
       - checkout
-      - revenuecat/install-gem-unix-dependencies:
-          cache-version: v1
+      - revenuecat/install-mise-tools:
+          tools: java
       - yarn-dependencies-unix
       - run: yarn build
       - run: yarn verify:android
@@ -192,6 +193,8 @@ jobs:
     <<: *base-android-job
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - yarn-dependencies-unix
@@ -220,6 +223,8 @@ jobs:
     <<: *base-android-job
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - yarn-dependencies-unix
@@ -243,6 +248,8 @@ jobs:
     <<: *base-mac-job
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: ruby
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - yarn-dependencies-mac
@@ -275,6 +282,8 @@ jobs:
     <<: *base-mac-job
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: ruby
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - yarn-dependencies-mac
@@ -290,6 +299,8 @@ jobs:
       xcode: '26.4.1'
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: ruby
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - run:
@@ -324,6 +335,8 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - yarn-dependencies-unix
@@ -353,6 +366,8 @@ jobs:
     <<: *base-mac-job
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: ruby
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - install-nvm
@@ -375,6 +390,8 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: ruby
       - revenuecat/trust-github-key
       - revenuecat/setup-git-credentials
       - revenuecat/install-gem-unix-dependencies:
@@ -439,6 +456,8 @@ jobs:
       - image: cimg/ruby:3.2.0
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: ruby
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - run:
@@ -460,6 +479,8 @@ jobs:
     <<: *base-mac-job
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: ruby
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - yarn-dependencies-mac
@@ -527,6 +548,7 @@ workflows:
             - verify-android-agp9-legacy-kotlin
           <<: *release-branches
       - revenuecat/tag-current-branch:
+          ruby_version: "3.3.0"
           requires:
             - hold
           <<: *release-branches
@@ -538,13 +560,15 @@ workflows:
           <<: *release-tags
       - revenuecat/merge-release-pr:
           repo_name: purchases-capacitor
+          ruby_version: "3.3.0"
           requires:
             - make-release-ui
           <<: *release-tags
 
   danger:
     jobs:
-      - revenuecat/danger
+      - revenuecat/danger:
+          ruby_version: "3.3.0"
 
   weekly-run-workflow:
     when:

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,8 @@ source "https://rubygems.org"
 gem 'fastlane'
 gem 'cocoapods'
 gem 'danger'
+# Works around a Ruby 3.3+ terminfo crash in fastlane on macOS:
+# https://github.com/fastlane/fastlane/issues/21794
+gem 'rb-readline'
 
 eval_gemfile("fastlane/Pluginfile")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,6 +314,7 @@ GEM
     public_suffix (4.0.7)
     racc (1.8.1)
     rake (13.4.2)
+    rb-readline (0.5.5)
     rchardet (1.10.2)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -384,6 +385,7 @@ DEPENDENCIES
   danger
   fastlane
   fastlane-plugin-revenuecat_internal!
+  rb-readline
 
 BUNDLED WITH
    2.4.13

--- a/mise.lock
+++ b/mise.lock
@@ -3,3 +3,68 @@
 [[tools.java]]
 version = "liberica-21.0.6+10"
 backend = "core:java"
+
+[tools.java."platforms.linux-arm64"]
+checksum = "sha1:32b10a97672c3b0066837deaf430dd7b52618f69"
+url = "https://github.com/bell-sw/Liberica/releases/download/21.0.6%2B10/bellsoft-jdk21.0.6%2B10-linux-aarch64.tar.gz"
+
+[tools.java."platforms.linux-x64"]
+checksum = "sha1:854e27442efaf515c9f15dbc7f4382c7a18be48b"
+url = "https://github.com/bell-sw/Liberica/releases/download/21.0.6%2B10/bellsoft-jdk21.0.6%2B10-linux-amd64.tar.gz"
+
+[tools.java."platforms.macos-arm64"]
+checksum = "sha1:347d99da2efef158ce1c02c871737ef3254d1701"
+url = "https://github.com/bell-sw/Liberica/releases/download/21.0.6%2B10/bellsoft-jdk21.0.6%2B10-macos-aarch64.tar.gz"
+
+[tools.java."platforms.macos-x64"]
+checksum = "sha1:1018e317ae83cf72221f8ded2ab213347802cb5c"
+url = "https://github.com/bell-sw/Liberica/releases/download/21.0.6%2B10/bellsoft-jdk21.0.6%2B10-macos-amd64.tar.gz"
+
+[[tools.node]]
+version = "24.18.0"
+backend = "core:node"
+
+[tools.node."platforms.linux-arm64"]
+checksum = "sha256:6b4484c2190274175df9aa8f28e2d758a819cb1c1fe6ab481e2f95b463ab8508"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-arm64.tar.gz"
+
+[tools.node."platforms.linux-x64"]
+checksum = "sha256:783130984963db7ba9cbd01089eaf2c2efb055c7c1693c943174b967b3050cb8"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-x64.tar.gz"
+
+[tools.node."platforms.macos-arm64"]
+checksum = "sha256:e1a97e14c99c803e96c7339403282ea05a499c32f8d83defe9ef5ec66f979ed1"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-darwin-arm64.tar.gz"
+
+[tools.node."platforms.macos-x64"]
+checksum = "sha256:dfd0dbd3e721503434df7b7205e719f61b3a3a31b2bcf9729b8b91fea240f080"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-darwin-x64.tar.gz"
+
+[[tools.ruby]]
+version = "3.3.0"
+backend = "core:ruby"
+
+[tools.ruby.options]
+compile = "false"
+precompiled_url = "jdx/ruby"
+ruby_build_repo = "https://github.com/rbenv/ruby-build.git"
+ruby_install = "false"
+
+[tools.ruby."platforms.linux-arm64"]
+checksum = "sha256:d03e0e1dc566aa6512baffb9373be48d36d4fde3ca9b58e0184eb5113a507eda"
+url = "https://github.com/jdx/ruby/releases/download/3.3.0-4/ruby-3.3.0.arm64_linux.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruby."platforms.linux-x64"]
+checksum = "sha256:7b2cec2a09b60b225b2b216938332ea009cf17dd21b9a2096aeaf963df957641"
+url = "https://github.com/jdx/ruby/releases/download/3.3.0-4/ruby-3.3.0.x86_64_linux.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruby."platforms.macos-arm64"]
+checksum = "sha256:0f3be0a98f46c6771f546ae753a6affd5f87dda4e5fbb222424c39a7fa82a99a"
+url = "https://github.com/jdx/ruby/releases/download/3.3.0-4/ruby-3.3.0.macos.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruby."platforms.macos-x64"]
+checksum = "sha256:96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d"
+url = "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,13 @@
 [settings]
 lockfile = true
 
+[settings.node]
+corepack = true
+
+[settings.ruby]
+compile = false
+
 [tools]
 java = "liberica-21.0.6"
+node = "24.18.0"
+ruby = "3.3.0"


### PR DESCRIPTION
Wires mise into CI for Node, Ruby, and JDK. `mise.toml` already pinned Java (#821, local-dev only); this closes the CI gap and adds Node/corepack + Ruby.

- JDK: wired into the 5 Gradle jobs (was unpinned).
- Node: was floating (`nvm install --lts`); now pinned to 24.18.0 via corepack, replacing the `circleci/node` orb.
- Ruby: was ambient everywhere; wired into every job using fastlane/cocoapods, bumped to 3.3.0 + `rb-readline` (fastlane#21794), orb `ruby_version` params bumped to match.
- Removed a wasted gem-install in `run-tests-android` (no `bundle exec` there).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every major CI job and bumps Ruby from ambient/3.2 images to mise 3.3.0; failures would block builds and releases but do not change runtime app code or secrets handling.
> 
> **Overview**
> **CI now installs Node, Ruby, and Java through mise** instead of the CircleCI Node orb, ambient Ruby, and unpinned JDK on Gradle jobs. Node is pinned to **24.18.0** with corepack; Ruby to **3.3.0** on fastlane/cocoapods jobs; JDK stays **Liberica 21.0.6** via the existing `mise.toml` pin, now used on Android Gradle work.
> 
> The shared `install-nvm` step calls `revenuecat/install-mise-tools` for Node. Jobs that need Ruby, Java, or both get targeted `install-mise-tools` steps before gems/yarn. Release orb steps (`tag-current-branch`, `merge-release-pr`, `danger`) pass **`ruby_version: "3.3.0"`**.
> 
> **Gemfile** adds **`rb-readline`** to avoid a fastlane terminfo crash on Ruby 3.3+ on macOS. **`mise.lock`** is expanded with locked Node and Ruby (and fuller Java) download checksums.
> 
> **`run-tests-android`** drops gem install only used elsewhere— that job does not run `bundle exec`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53d1b695f1c1c5f352cecc78ef07ba5a770361ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->