### PR TITLE
[EXTERNAL] Remove package attribute from AndroidManifest.xml

### DIFF
--- a/purchases-capacitor-ui/android/src/main/AndroidManifest.xml
+++ b/purchases-capacitor-ui/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.revenuecat.purchases.capacitor.ui">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     
     <application>
         <!-- No specific activities need to be declared here since they are included in the 'purchases-ui' library -->


### PR DESCRIPTION
- Fixes #878 - a build warning on android.

Thank you for contributing to RevenueCat/purchases-capacitor. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [ ] ~If applicable, unit tests.~

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only cleanup with no logic or permission changes; typical AGP migration with negligible runtime impact.
> 
> **Overview**
> Removes the deprecated `package="com.revenuecat.purchases.capacitor.ui"` attribute from the `purchases-capacitor-ui` Android manifest root element, leaving only the `xmlns:android` declaration.
> 
> This aligns with modern Android Gradle Plugin expectations (namespace from Gradle) and clears the build warning reported in #878. Manifest content under `<application>` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5768f9e9319efd6291a419710ee72fd330fbbf4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->