### PR TITLE
[EXTERNAL] Remove deprecated package attribute from purchases-capacitor-ui AndroidManifest (#879) via @HarelM

### DIFF
--- a/purchases-capacitor-ui/android/src/main/AndroidManifest.xml
+++ b/purchases-capacitor-ui/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.revenuecat.purchases.capacitor.ui">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     
     <application>
         <!-- No specific activities need to be declared here since they are included in the 'purchases-ui' library -->


### PR DESCRIPTION
External contribution from @HarelM, merged into this branch to run CI. Original PR: #879

Fixes #878

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only cleanup with namespace already set in build.gradle; no runtime or security behavior change.
> 
> **Overview**
> Removes the deprecated **`package`** attribute from **`purchases-capacitor-ui`**’s **`AndroidManifest.xml`**, which addresses build warnings/errors tied to **#878** on current Android Gradle Plugin versions.
> 
> The library identity stays **`com.revenuecat.purchases.capacitor.ui`** via **`namespace`** in **`build.gradle`**; manifest contents (empty **`application`**) are unchanged aside from dropping the redundant **`package`** declaration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d33232134fed51ed6999a8196da26866d1c3e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->