### PR TITLE
Update sdks-common-config orb to v4.6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   macos: circleci/macos@2.3.6
   android: circleci/android@3.0.2
-  revenuecat: revenuecat/sdks-common-config@4.6.0
+  revenuecat: revenuecat/sdks-common-config@4.6.1
 
 aliases:
   base-mac-job: &base-mac-job


### PR DESCRIPTION
### Motivation

Keep CI on the latest shared orb release: [v4.6.1](https://github.com/RevenueCat/sdks-circleci-orb/releases/tag/v4.6.1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level CI orb bump only; no application or pipeline definition changes in this repo.
> 
> **Overview**
> Bumps the CircleCI `revenuecat/sdks-common-config` orb from **4.6.0** to **4.6.1** so CI uses the latest shared SDK config. No job or workflow changes in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d70ebb91dabff5eb18e8a56c3cbde5cf9a22fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->