### PR TITLE
ci: bump external PR notifications workflow to v8

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -8,6 +8,6 @@ permissions: {}
 
 jobs:
   notify:
-    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@b679120ce2931ac2e5c02166f84ad1f9b263fb96 # v8
     secrets:
       EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Bumps the shared workflow to `v8`, which gates on `head.repo.fork` instead of `author_association` so PRs from org members with private membership stop being posted as external. See RevenueCat/sdk-github-workflows#11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow version bump with no application code changes; behavior change is limited to Slack notification targeting for PR opens.
> 
> **Overview**
> Updates the **External PR Notifications** reusable workflow pin from **v7** to **v8** of `revenuecat/sdk-github-workflows`.
> 
> That upstream release changes how “external” PRs are detected: it uses **`head.repo.fork`** instead of **`author_association`**, so Slack notifications for opened PRs no longer misclassify contributions from org members with private membership as external.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d744c284ab9392c70faa5a10ede26f574e0e8fb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->